### PR TITLE
Fix rm command syntax in installer script

### DIFF
--- a/linux/installer.sh
+++ b/linux/installer.sh
@@ -223,7 +223,7 @@ update_elite_intel() {
     local ELITE_ZIP="elite_intel*.zip"
     unzip -o "$ELITE_ZIP" elite_intel.jar dictionary/stt-correction-dictionary.txt -d "$ELITEINTEL_FOLDER"
     
-    rm "$ELITE_ZIP"
+    rm $ELITE_ZIP
 
     echo "Done!"
     echo "Fly Dangerous, commander"


### PR DESCRIPTION
**Update function error**
Removed quotes around file name, it was translating the literal string variable, instead of looking for the .zip