### PR TITLE
Add multilingual action aliases and Unicode-aware action reduction

### DIFF
--- a/app/src/main/java/elite/intel/ai/brain/AiActionsMap.java
+++ b/app/src/main/java/elite/intel/ai/brain/AiActionsMap.java
@@ -1,5 +1,6 @@
 package elite.intel.ai.brain;
 
+import elite.intel.ai.brain.i18n.AiActionLocalizations;
 import elite.intel.session.Status;
 import elite.intel.session.SystemSession;
 
@@ -41,229 +42,17 @@ public class AiActionsMap {
     public Map<String, String> actionMap(boolean isDryRun) {
         Map<String, String> map = new LinkedHashMap<>();
 
-        // always available
-        map.put("wake up", WAKEUP.getAction());
-        map.put("sleep, go to sleep, ignore me, do not monitor", SLEEP.getAction());
-        map.put("interrupt", INTERRUPT_TTS.getAction());
+        // Add aliases only for the currently selected language.
+        AiActionLocalizations.addAliases(map, status, isDryRun);
 
-        // navigation
-        map.put("navigate to coordinates {lat:X, lon:Y}", NAVIGATE_TO_TARGET.getAction());
-        map.put("navigate to active mission, plot route to active mission, plot route to mission, take me to mission, go to mission {key:X}", NAVIGATE_TO_NEXT_MISSION.getAction());
-        map.put("navigate to fleet carrier, go to carrier, head to carrier, return to carrier, take us to carrier", NAVIGATE_TO_CARRIER.getAction());
-        map.put("navigate to landing zone, bearing to landing zone, heading to landing zone, back to LZ", GET_HEADING_TO_LZ.getAction());
-        map.put("navigate to next trade stop, go to next trade stop", NAVIGATE_TO_NEXT_TRADE_STOP.getAction());
-        map.put("navigate from memory, paste from memory", NAVIGATE_TO_ADDRESS_FROM_MEMORY.getAction());
-        map.put("cancel navigation, abort navigation, stop navigation", NAVIGATION_OFF.getAction());
-        map.put("set home system, set current system as home, mark home system", SET_HOME_SYSTEM.getAction());
-        map.put("take me home, go home, navigate home, return home, plot route home, head home, take us home", TAKE_ME_HOME.getAction());
-
-        if (status.isInMainShip() || isDryRun) {
-            // navigation
-            map.put("select fds destination, target destination, set destination, select target destination", TARGET_DESTINATION.getAction());
-            map.put("jump to hyperspace,  jump, hyperspace jump, enter hyperspace, lets go, next way point, let's go", JUMP_TO_HYPERSPACE.getAction());
-            map.put("drop out, drop here, drop ftl, drop from supercruise, leave supercruise, drop in", DROP_FROM_SUPER_CRUISE.getAction());
-            map.put("enter supercruise, supercruise, go supercruise", ENTER_SUPER_CRUISE.getAction());
-            map.put("launch ship, launch, detach from station, leave port, leave station", LAUNCH_SHIP.getAction());
-            // speed / throttle
-            map.put("stop engines, stop here, full stop, all stop, halt, kill engines, cut throttle, zero throttle, stop ship", SET_SPEED_ZERO.getAction());
-            map.put("taxi to landing, taxi, auto land, autopilot landing", TAXI.getAction());
-            map.put("quarter throttle, 25 percent, slow speed, one quarter", SET_SPEED25.getAction());
-            map.put("half throttle, 50 percent, half speed", SET_SPEED50.getAction());
-            map.put("three quarters throttle, 75 percent, three quarter speed", SET_SPEED75.getAction());
-            map.put("full throttle, 100 percent, full speed, maximum speed, max throttle", SET_SPEED100.getAction());
-            map.put("increase speed by {key:X}", INCREASE_SPEED_BY.getAction());
-            map.put("decrease speed by {key:X}", DECREASE_SPEED_BY.getAction());
-            map.put("set optimal speed, optimal approach speed, optimize approach speed", SET_OPTIMAL_SPEED.getAction());
-            map.put("landing gear, gear down, lower landing gear, extend landing gear", DEPLOY_LANDING_GEAR.getAction());
-            map.put("retract landing gear, gear up, raise landing gear, stow landing gear", RETRACT_LANDING_GEAR.getAction());
-            map.put("request docking, dock at station, request landing, docking request, ask for docking, request parking, parking spot, request pad, park ship", REQUEST_DOCKING.getAction());
-            // UI panels
-            map.put("show, open or display fighter panel", SHOW_FIGHTER_PANEL.getAction());
-
-            // combat
-            map.put("deploy hardpoints, weapons hot, combat ready, weapons free, weapons out, arm weapons, weapons ready", DEPLOY_HARDPOINTS.getAction());
-            map.put("retract hardpoints, weapons cold, weapons away, stand down, holster weapons, weapons down, safe weapons", RETRACT_HARDPOINTS.getAction());
-            map.put("target fsd {key:fsd}, target engines {key:drive}, target Power Distributor {key:power distributor} target power plant {key:powerplant}, target powerplant {key:powerplant}, target life support {key:life support}, ", TARGET_SUB_SYSTEM.getAction());
-            map.put("target wingman 1, wingman alpha", TARGET_WINGMAN0.getAction());
-            map.put("target wingman 2, wingman bravo", TARGET_WINGMAN1.getAction());
-            map.put("target wingman 3, wingman charlie", TARGET_WINGMAN2.getAction());
-            map.put("wing nav lock, lock wingman nav, follow wingman", WING_NAV_LOCK.getAction());
-            map.put("priority target, target highest threat, target most dangerous, select hostile, next enemy, select enemy", SELECT_HIGHEST_THREAT.getAction());
-            // vehicle deployment
-            map.put("deploy SRV, deploy vehicle, launch SRV, send out SRV, drop SRV", DEPLOY_SRV.getAction());
-            map.put("deploy heat sink, launch heat sink, dump heat", DEPLOY_HEAT_SINK.getAction());
-            // fighter orders
-            map.put("deploy fighter, launch fighter, send out fighter", DEPLOY_FIGHTER.getAction());
-            map.put("order fighter defend ship, fighter defend, fighter defensive", FIGHTER_REQUEST_DEFENSIVE_BEHAVIOUR.getAction());
-            map.put("order fighter attack my target, fighter attack, sic fighter on target, focus my target, focus target, focus on target, fighter focus target", FIGHTER_REQUEST_FOCUS_TARGET.getAction());
-            map.put("order fighter hold fire, fighter cease fire, fighter stand down", FIGHTER_REQUEST_HOLD_FIRE.getAction());
-            map.put("order fighter return to ship, fighter dock, recall fighter", FIGHTER_REQUEST_REQUEST_DOCK.getAction());
-            map.put("fighter open orders, fire at will, attack at will", FIGHTER_OPEN_ORDERS.getAction());
-        }
-
-        if (status.isInMainShip() && !status.isDocked() || isDryRun) {
-            map.put("stations in system, what stations, nearby stations, star ports, space stations, docking available", QUERY_STATIONS.getAction());
-        }
-
-        if (status.isInSrv() && status.isDocked() || isDryRun) {
-            map.put("show services panel, open services panel, display services panel, show station services panel", SHOW_STATION_SERVICES.getAction());
-        }
-
-        if (status.isInMainShip() || status.isInSrv() || isDryRun) {
-            // flight / ship systems
-            map.put("switch to combat mode", ACTIVATE_COMBAT_MODE.getAction());
-            map.put("switch to analysis mode", ACTIVATE_ANALYSIS_MODE.getAction());
-            map.put("cargo scoop, open cargo scoop, close cargo scoop, deploy cargo scoop, retract cargo scoop, open cargo bay, close cargo bay", TOGGLE_CARGO_SCOOP.getAction());
-            map.put("night vision, nightvision, turn on night vision, turn off night vision {state:true/false}", NIGHT_VISION_ON_OFF.getAction());
-            map.put("headlights, lights, turn off lights, turn on lights, ship lights, lights on, lights off {state:true/false}", LIGHTS_ON_OFF.getAction());
-            // UI panels
-            map.put("show, open or display commander, central, role panel, open knee board", SHOW_COMMANDER_PANEL.getAction());
-            map.put("show, open or display crew panel", SHOW_CREW.getAction());
-            map.put("show, open or display home panel", SHOW_INTERNAL_PANEL.getAction());
-            map.put("show, open or display modules panel", SHOW_MODULES_PANEL.getAction());
-            map.put("show, open or display fire groups", SHOW_FIRE_GROUPS.getAction());
-            map.put("show, open or display inventory panel", SHOW_INVENTORY_PANEL.getAction());
-            map.put("show, open or display storage panel", SHOW_STORAGE_PANEL.getAction());
-            // power
-            map.put("power to shields, max shields, boost shields", INCREASE_SHIELDS_POWER.getAction());
-            map.put("power to engines, max engines, boost engines", INCREASE_ENGINES_POWER.getAction());
-            map.put("power to weapons, max weapons, boost weapons", INCREASE_WEAPONS_POWER.getAction());
-            // vehicle deployment
-            map.put("disembark", DISEMBARK.getAction());
-            map.put("equalize power, balance power, reset power, distribute power equally", RESET_POWER.getAction());
-        }
-
-        if (status.isInSrv() || isDryRun) {
-            map.put("drive assist, driving assist, SRV assist {state:true/false}", DRIVE_ASSIST.getAction());
-            map.put("recover SRV, board ship, return SRV, retrieve SRV, SRV dock", RECOVER_SRV.getAction());
-        }
-
-        if (status.isInSrv() || status.isOnFoot() || isDryRun) {
-            map.put("dismiss ship, send ship away, ship to orbit", DISMISS_SHIP.getAction());
-            map.put("return to surface, pick me up", RETURN_TO_SURFACE.getAction());
-        }
-
-        // market / traders / brokers
-        map.put("find raw material trader, raw trader, where to trade raw materials {key:X}", FIND_RAW_MATERIAL_TRADER.getAction());
-        map.put("find encoded material trader, encoded trader, data trader {key:X}", FIND_ENCODED_MATERIAL_TRADER.getAction());
-        map.put("find manufactured material trader, manufactured trader {key:X}", FIND_MANUFACTURED_MATERIAL_TRADER.getAction());
-        map.put("find human tech broker, human technology broker {key:X}", FIND_HUMAN_TECHNOLOGY_BROKER.getAction());
-        map.put("find guardian tech broker, guardian technology broker {key:X}", FIND_GUARDIAN_TECHNOLOGY_BROKER.getAction());
-        map.put("find commodity, find nearest commodity, buy commodity, where to buy, find market{key:X, max_distance:Y, state:true/false}", FIND_COMMODITY.getAction());
-        map.put("find nearest fleet carrier, nearest carrier", FIND_NEAREST_FLEET_CARRIER.getAction());
-
-        // fleet carrier
-        map.put("set carrier fuel reserve, carrier tritium reserve {key:X}", SET_CARRIER_FUEL_RESERVE.getAction());
-        map.put("calculate fleet carrier route, plan carrier route, carrier jump route", CALCULATE_FLEET_CARRIER_ROUTE.getAction());
-        map.put("enter carrier destination, set carrier destination, carrier destination", ENTER_FLEET_CARRIER_DESTINATION.getAction());
-
-        // trade
-        map.put("calculate trade route", CALCULATE_TRADE_ROUTE.getAction());
-        map.put("list trade route parameters", LIST_TRADE_ROUTE_PARAMETERS.getAction());
-        map.put("monetize route", MONETIZE_ROUTE.getAction());
-
-        map.put("change trade profile starting budget {key:X}", CHANGE_TRADE_PROFILE_SET_STARTING_BUDGET.getAction());
-        map.put("change trade profile max stops {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_NUMBER_OF_STOPS.getAction());
-        map.put("change trade profile max distance {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_DISTANCE_FROM_ENTRY.getAction());
-        map.put("change trade profile allow prohibited cargo {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PROHIBITED_CARGO.getAction());
-        map.put("change trade profile allow planetary port {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PLANETARY_PORT.getAction());
-        map.put("change trade profile allow permit systems {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PERMIT_SYSTEMS.getAction());
-        map.put("change trade profile allow strongholds {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_STRONGHOLDS.getAction());
-
-        // announcements / app settings
-        map.put("toggle radio, radio traffic, radio transmissions {state:true/false}", SET_RADIO_TRANSMISSION_MODE.getAction());
-        map.put("radar contact announcement {state:true/false}", SET_RADAR_CONTACT_ANNOUNCEMENT.getAction());
-        map.put("discovery announcements {state:true/false}", DISCOVERY_ON_OFF.getAction());
-        map.put("route announcements {state:true/false}", ROUTE_ON_OFF.getAction());
-        map.put("disable all announcements", DISABLE_ALL_ANNOUNCEMENTS.getAction());
-        map.put("clear reminders", CLEAR_REMINDERS.getAction());
-        map.put("set reminder {key:X}", SET_REMINDER.getAction());
-
-        // UI panels
-        map.put("activate", ACTIVATE.getAction());
-        map.put("show, open or display transactions panel", SHOW_TRANSACTIONS.getAction());
-        map.put("show, open or display contacts panel", SHOW_CONTACTS.getAction());
-        map.put("show, open or display navigation panel", SHOW_NAVIGATION.getAction());
-        map.put("show, open or display chat panel, comms panel", SHOW_CHAT_PANEL.getAction());
-        map.put("show, open or display email inbox panel, email", SHOW_INBOX_PANEL.getAction());
-        map.put("show, open or display social panel", SHOW_SOCIAL_PANEL.getAction());
-        map.put("show, open or display history panel", SHOW_HISTORY_PANEL.getAction());
-        map.put("show, open or display squadron panel", SHOW_SQUADRON.getAction());
-        map.put("show, open or display status panel", SHOW_STATUS_PANEL.getAction());
-        map.put("show, open or display carrier management panel", DISPLAY_CARRIER_MANAGEMENT.getAction());
-        map.put("show, open or display galaxy map", OPEN_GALAXY_MAP.getAction());
-        map.put("show, open or display local / stat system map", OPEN_SYSTEM_MAP.getAction());
-        map.put("exit close panel", EXIT_CLOSE.getAction());
-
-        // pirate massacre missions
-        map.put("navigate to mission provider system", RECON_PROVIDER_SYSTEM.getAction());
-        map.put("navigate to pirate mission provider", NAVIGATE_TO_PIRATE_MISSION_PROVIDER.getAction());
-        map.put("active missions, current missions, mission log, what missions, mission status, what are our missions, ongoing missions, mission board", ANALYZE_MISSIONS.getAction());
-        map.put("pirate mission, kill count, how many kills, massacre mission progress, kills remaining, massacre progress, pirates remaining, pirate kills, bounty hunt progress", PIRATE_MISSION_PROGRESS.getAction());
-        map.put("find hunting grounds {key:X}", FIND_HUNTING_GROUNDS.getAction());
-        map.put("recon hunting ground, navigate to target system, navigate to hunting ground", RECON_TARGET_SYSTEM.getAction());
-        map.put("ignore hunting ground", IGNORE_HUNTING_GROUND.getAction());
-        map.put("confirm hunting ground, confirm target star system", CONFIRM_HUNTING_GROUND.getAction());
-
-        // science / mining / biology
-        map.put("add mining target {key:X}", ADD_MINING_TARGET.getAction());
-        map.put("remove mining target {key:X}", REMOVE_MINING_TARGET.getAction());
-        map.put("clear mining targets", CLEAR_MINING_TARGETS.getAction());
-        map.put("mining announcements {state:true/false}", MINING_ON_OFF.getAction());
-        map.put("find brain trees {key:X, max_distance:Y}", FIND_BRAIN_TREES.getAction());
-        map.put("find mining site, find mining location, find mining hotspot, find where to mine, find asteroid field {key:X, max_distance:Y}", FIND_MINING_SITE.getAction());
-        map.put("find tritium mining site, find tritium field {key:X, max_distance:Y}", FIND_FLEET_CARRIER_FUEL_MINING_SITE.getAction());
-        map.put("navigate to next bio sample, go to next sample, navigate to next organic, codex entry, navigate to codex entry, navigate to codex", NAVIGATE_TO_NEXT_BIO_SAMPLE.getAction());
-        map.put("scan the system, open fss, full scan, honk, system scan, discovery scan, FSS, full spectrum scan, scan system", OPEN_FSS_AND_SCAN.getAction());
-        map.put("find nearest vista genomics, find genomics, vista genomics", FIND_VISTA_GENOMICS.getAction());
-        map.put("delete codex entry, delete this codex, delete this entry, delete this organic", DELETE_CODEX_ENTRY.getAction());
-
-        map.put("check key bindings, missing key bindings, unbound keys, keyboard bindings, keybind check, missing bindings", KEY_BINDINGS_ANALYSIS.getAction());
-        map.put("bio signals done within the star system, organics scanned in star system, how many bio samples in star system, bio signals in system, bio samples in star system, biological signals in star system, organics in system, which planets have bio signals, which planets still need bio scans, which planets need organic scans, which planets still need scanning, bio scan needed on which planets, planets with unscanned bio signals, bio scan progress", BIO_SAMPLE_IN_STAR_SYSTEM.getAction());
-        map.put("exobiology samples, biology samples, organics at location, what organisms, what's left to scan, remaining organisms, samples left, organisms remaining, exobiology progress, scan remaining, what bio scans completed, what bio scans have we completed, bio scans done, bio scans completed, organics on this planet, biology on this planet, what organisms are here, what organisms are on this planet, bio sample progress on planet, what's been scanned here, what organics do we still have to scan, what organics still to scan, organics still to scan, organics remaining to scan, organics left to scan, what organics remain, biology still to scan, what biology remains, what do we still need to scan here", EXOBIOLOGY_SAMPLES.getAction());
-        map.put("distance to last bio sample, how far to sample, how far to last organism, range to bio sample, how far to previous organism, navigate to bio sample", DISTANCE_TO_LAST_BIO_SAMPLE.getAction());
-        map.put("analyze biome, biome analysis, what biome {key:X}, planetary biome, atmosphere analysis, what life is here, biome type", PLANET_BIOME_ANALYSIS.getAction());
-        map.put("stellar objects, planets in system, landable planets, is planet or moon landable, bodies in system, what planets, how many planets, system bodies, stellar bodies, ice rings, planetary rings, rings in system, has rings, ring system", QUERY_STELLAR_OBJETS.getAction());
-        map.put("signals in system, what signals are in this system, what's in this system, what's detected in system, what signals here, what signals do you see, what signals do you detect, what signals can you see, FSS signals, mining hot spots, resource extraction sites, what signals, conflict zones, emissions, unidentified signals, system signals, detected signals, anomalous signals", QUERY_STELLAR_SIGNALS.getAction());
-        map.put("geo signals, geological signals, volcanic signals, geological activity, volcanic activity, geology in system", QUERY_GEO_SIGNALS.getAction());
-
-        map.put("fleet carriers in system, carriers in system, how many carriers, fleet carriers here, any carriers nearby", QUERY_CARRIERS.getAction());
-        map.put("carrier route, carrier navigation, carrier jump route, carrier trip, carrier journey, carrier travel plan, how many jumps on carrier route, jumps remaining on carrier, carrier route jump count, jumps left on carrier", CARRIER_ROUTE_ANALYSIS.getAction());
-        map.put("carrier route, where is carrier going, carrier next jump, where is carrier headed, carrier heading, carrier endpoint, carrier final destination", CARRIER_ROUTE.getAction());
-        map.put("carrier tritium, carrier fuel, how much tritium, tritium supply, tritium level, carrier fuel level, tritium reserve, carrier tritium status", CARRIER_TRITIUM_SUPPLY.getAction());
-        map.put("carrier status, carrier finances, carrier balance, carrier overview, carrier funds, how long can we operate carrier, carrier fuel status, fleet carrier fuel status, how far can carrier jump, carrier jump range with current tritium, carrier tritium range", CARRIER_STATUS.getAction());
-        map.put("carrier ETA, when does carrier arrive, how long until carrier, carrier arrival time, carrier arrival, when does carrier jump, carrier jump time", CARRIER_ETA.getAction());
-        map.put("distance to carrier, where is our carrier, how far is carrier, where is our carrier, range to carrier, carrier proximity, how far away is carrier", DISTANCE_TO_CARRIER.getAction());
-        map.put("system security, faction control, who controls, power struggle, security level, who owns this system, dominant faction, controlling power", SYSTEM_SECURITY_ANALYSIS.getAction());
-        map.put("trade profile, trade settings, trading parameters, trade configuration, trading criteria", TRADE_PROFILE_ANALYSIS.getAction());
-        map.put("distance to stellar object, how far to body, distance to planet {key:X}, range to planet, how far to moon, how far to station, range to body. NOTE: Sol and Earth always mean the bubble/civilization - never use this action for Sol or Earth", DISTANCE_TO_BODY.getAction());
-        map.put("last scan, what did we scan, last scanned object, most recent scan, latest scan, recent body scan, what did i last scan", LAST_SCAN_ANALYSIS.getAction());
-        map.put("material inventory {key:X}, how many items {key:X}, how many guardian item {key:X}, how much material {key:X}, do we have material {key:X}, how much {key:X} do we have, do we have any {key:X}, engineering material {key:X}, raw material {key:X}, manufactured material {key:X}, encoded material {key:X}, material stock {key:X}", MATERIALS_INVENTORY.getAction());
-        map.put("planet materials, materials here, what materials on this planet, surface materials, what materials are here, material deposits, minerals on planet", PLANET_MATERIALS.getAction());
-        map.put("exploration profits, discovery profits, how much exploration worth, exploration value, scan value, mapping profit, exobiology value, scan earnings, what are scans worth", EXPLORATION_PROFITS.getAction());
-        map.put("query current location, where are we, our position, what system are we in, where am i, our coordinates, current system, what planet are we at, our current position, day length", CURRENT_LOCATION.getAction());
-        map.put("FSD target info, analyze destination, what star are we targeting, analyze fsd target, information on fsd target", FSD_TARGET_ANALYSIS.getAction());
-        map.put("plotted route, fuel at next stop, fuel availability on route, route analysis, are we there yet, current route, navigation route, jumps remaining, jumps left, how many jumps, next star scoopable, fuel stop", PLOTTED_ROUTE_ANALYSIS.getAction());
-        map.put("trade route, trading route, current trade plan, what are we trading, our trading plan, trading schedule, trade legs", TRADE_ROUTE_ANALYSIS.getAction());
-        map.put("outfitting, ship upgrades, modules available, what modules at station, available modules, available equipment, buy modules, ship parts, station equipment", LOCAL_OUTFITTING.getAction());
-        map.put("shipyard, ships for sale, what ships at station, buy a ship, available ships, ships to buy, new ship", LOCAL_SHIPYARD.getAction());
-        map.put("what is in our cargo hold, what are we carrying, cargo contents, commodities on board, what are we hauling, hold contents", CARGO_HOLD_CONTENTS.getAction());
-        map.put("player profile", PLAYER_PROFILE_ANALYSIS.getAction());
-        map.put("ship loadout, damage report, ship modules, combat readiness report, ship equipment, ship specs, what am I flying, what are we equipped with, do you have, is it equipped, shield generator, hull reinforcement, sensors, thrusters, frameshift, fuel scoop, installed", SHIP_LOADOUT.getAction());
-        map.put("station details, what services here, what services are here, services here, what services does this station have, services at this station, what does station offer, station info, station facilities, what's at this station, services available", STATION_DETAILS.getAction());
-        map.put("bounties, total bounties, bounty collected, how much in bounties, bounty earnings, credits from bounties, bounty credits", TOTAL_BOUNTIES.getAction());
-        map.put("distance to bubble, distance to sol, distance from sol, distance to Earth, distance from Earth, how far from sol, how far from bubble, how far from inhabited space, distance from inhabited space, how far from civilization, range from human space", DISTANCE_TO_BUBBLE.getAction());
-        map.put("current time, what time is it, time on earth, galactic time, utc time, what's the time, real time", TIME_IN_ZONE.getAction());
-        map.put("reminder, what was the reminder, destination reminder, any reminders, recall reminder, what did we set as reminder", REMINDER.getAction());
-        map.put("local markets, markets at stations and settlements, markets at outposts in system", ANALYZE_MARKETS.getAction());
-
+        // Conversation / ignore fallback is language-independent because these are internal action names.
         if (systemSession.conversationalModeOn()) {
             map.put("general conversation", GENERAL_CONVERSATION.getAction());
         } else {
             map.put("ignore_nonsensical_input", IGNORE_NONSENSE.getAction());
         }
 
-        // machine-only
+        // Machine-only command, not user-facing language.
         map.put(CONNECTION_CHECK_COMMAND, CONNECTION_CHECK.getAction());
 
         return map;

--- a/app/src/main/java/elite/intel/ai/brain/Reducer.java
+++ b/app/src/main/java/elite/intel/ai/brain/Reducer.java
@@ -54,18 +54,65 @@ public class Reducer {
      * @return a reduced map containing only the entries whose keys match significant words from the normalized input;
      *         may return a map with fallback values if the input is empty or irrelevant
      */
-    public static Map<String, String> reduce(String normalizedInput, Map<String, String> full, boolean isConversationMode) {
-        if (normalizedInput == null || normalizedInput.isBlank()) return full;
+    public static Map<String, String> reduce(
+            String normalizedInput,
+            Map<String, String> full,
+            boolean isConversationMode
+    ) {
+        if (normalizedInput == null || normalizedInput.isBlank()) {
+            return full;
+        }
 
-        Set<String> inputWords = Arrays.stream(normalizedInput.toLowerCase().split("\\W+"))
+        // Preserve an exact alias match as a high-confidence candidate.
+        // This must not replace semantic classification; it only prevents
+        // the reducer from accidentally removing a valid action before the LLM sees it.
+        String directAction = full.get(normalizedInput);
+
+        // Use Unicode-aware tokenization.
+        // "\\W+" is too ASCII-centric and does not work reliably with Cyrillic,
+        // Ukrainian, German umlauts, and other non-English input.
+        Set<String> inputWords = Arrays.stream(
+                        normalizedInput
+                                .toLowerCase(Locale.ROOT)
+                                .split("[^\\p{L}\\p{N}_]+")
+                )
                 .filter(w -> w.length() > 2)
                 .filter(w -> !STOP_WORDS.contains(w))
                 .collect(Collectors.toSet());
 
-
         Map<String, String> result = new LinkedHashMap<>();
-        /// Ensure an escape hatch is present
-        if (inputWords.isEmpty()) {
+
+        // Add all actions whose trigger phrases share meaningful words
+        // with the normalized user input.
+        for (Map.Entry<String, String> entry : full.entrySet()) {
+            String trigger = entry.getKey();
+            String action = entry.getValue();
+
+            Set<String> triggerWords = Arrays.stream(
+                            trigger
+                                    .toLowerCase(Locale.ROOT)
+                                    .split("[^\\p{L}\\p{N}_]+")
+                    )
+                    .filter(w -> w.length() > 2)
+                    .filter(w -> !STOP_WORDS.contains(w))
+                    .collect(Collectors.toSet());
+
+            boolean hasOverlap = triggerWords.stream().anyMatch(inputWords::contains);
+
+            if (hasOverlap) {
+                result.put(trigger, action);
+            }
+        }
+
+        // If the user input exactly matches an alias from the action map,
+        // keep that action in the reduced candidate list.
+        // It is still only a candidate; the LLM remains responsible for final intent selection.
+        if (directAction != null) {
+            result.put(normalizedInput, directAction);
+        }
+
+        // If no candidate survived reduction, fall back according to the current mode.
+        if (result.isEmpty()) {
             if (isConversationMode) {
                 result.put(GENERAL_CONVERSATION.getAction(), GENERAL_CONVERSATION.getAction());
             } else {
@@ -73,17 +120,6 @@ public class Reducer {
             }
         }
 
-        for (Map.Entry<String, String> entry : full.entrySet()) {
-            // Strip param templates like {key:X, max_distance:Y} before matching to avoid
-            // false positives (e.g. "distance" matching "max_distance" in a param template).
-            String keyLower = entry.getKey().toLowerCase().replaceAll("\\{[^}]*\\}", "");
-            for (String word : inputWords) {
-                if (keyLower.contains(word)) {
-                    result.put(entry.getKey(), entry.getValue());
-                    break;
-                }
-            }
-        }
         return result;
     }
 

--- a/app/src/main/java/elite/intel/ai/brain/commons/PromptFactory.java
+++ b/app/src/main/java/elite/intel/ai/brain/commons/PromptFactory.java
@@ -55,8 +55,16 @@ public class PromptFactory implements AiPromptFactory {
                 Raw JSON only. No text, no markdown, no explanation before or after.
 
                 CLASSIFICATION:
-                - ABSOLUTE RULE - 'query_player_profile_rank_progress' requires an EXPLICIT player rank/profile request with ≥95% confidence. The input MUST begin with 'player profile' (these two words, in this order) and may optionally include additional qualifying words after them (e.g. 'player profile summarize ranks', 'player profile summarize progress'). If confidence is below 95%, or the input is ambiguous or tangentially related, fall back to ignore_nonsensical_input (strict mode) or query_general_conversation (conversational mode). This action is NEVER a fallback or closest-match - it must be explicitly requested. Violations are a critical failure.
-                - Default to COMMAND. Only use a QUERY action when the input is clearly interrogative (starts with: what, how, which, why, is, are, does, tell me, how much, how many).
+                   - User input may be in English, German, Russian, or Ukrainian. Interpret the user's intent semantically across these languages.
+                   - Internal action names are always English. The JSON "action" value MUST always be copied exactly from the available action list. Never translate action names.
+                   - ABSOLUTE RULE - 'query_player_profile_rank_progress' requires an EXPLICIT player rank/profile request with ≥95% confidence. The input MUST begin with 'player profile' (these two words, in this order) and may optionally include additional qualifying words after them (e.g. 'player profile summarize ranks', 'player profile summarize progress'). If confidence is below 95%, or the input is ambiguous or tangentially related, fall back to ignore_nonsensical_input (strict mode) or query_general_conversation (conversational mode). This action is NEVER a fallback or closest-match - it must be explicitly requested. Violations are a critical failure.
+                   - Default to COMMAND for instructions that ask to perform an action, change ship state, open a panel, navigate, deploy, retract, enable, disable, find, or search.
+                   - Use a QUERY action when the user asks for information, status, location, inventory, route, station, system, ship data, market data, materials, missions, signals, bodies, carrier data, or any other game-state lookup.
+                   - Query intent may be expressed in any supported language. Examples of query starters include:
+                     English: what, where, how, which, why, is, are, does, tell me, how much, how many
+                     German: was, wo, wie, welcher, welche, welches, warum, ist, sind, gibt es, wie viel, wie viele, auf welcher, in welchem
+                     Russian: что, где, как, какой, какая, какие, почему, есть ли, сколько, на какой, в какой, расскажи
+                     Ukrainian: що, де, як, який, яка, які, чому, чи є, скільки, на якій, в якій, розкажи
                 """);
 
         if (systemSession.conversationalModeOn()) {
@@ -87,9 +95,15 @@ public class PromptFactory implements AiPromptFactory {
         }
         sb.append("""
                 VERB INTENT (apply first, before matching any action):
-                - show / display / open / access / find / search / locate / activate → COMMANDS (open a panel or map, find commodities, missions etc.)
-                - where / tell me / how much / any → lookup QUERY (search data, speak result)
-                - delete_* actions require explicit intent in user input. Example "delete codex entry" - delete_* action allowed, "codex entry" - delete_* action not allowed
+                 - Action verbs usually mean COMMANDS: show / display / open / access / find / search / locate / activate / navigate / plot / deploy / retract / enable / disable / turn on / turn off.
+                 - German command verbs include: zeige / öffne / suche / finde / aktiviere / deaktiviere / navigiere / setze route / fahre aus / fahre ein / schalte ein / schalte aus.
+                 - Russian command verbs include: покажи / открой / найди / ищи / активируй / отключи / проложи маршрут / выпусти / убери / включи / выключи.
+                 - Ukrainian command verbs include: покажи / відкрий / знайди / шукай / активуй / вимкни / проклади маршрут / випусти / прибери / увімкни / вимкни.
+                 - Lookup/question phrases mean QUERY: where / tell me / how much / how many / any / what is / what are.
+                 - German query phrases include: wo / was / wie viel / wie viele / gibt es / welche / welcher / welches / auf welcher station / in welchem system.
+                 - Russian query phrases include: где / что / сколько / есть ли / какой / какая / какие / на какой станции / в какой системе.
+                 - Ukrainian query phrases include: де / що / скільки / чи є / який / яка / які / на якій станції / в якій системі.
+                 - delete_* actions require explicit intent in user input. Example "delete codex entry" - delete_* action allowed, "codex entry" - delete_* action not allowed.
                 
                 DISAMBIGUATION (genuine ambiguities only):
                 - "activate" (exact standalone word only, nothing else meaningful in input) → activate_ui_control. "toggle [X]", "engage [X]", "enable [X]" and other non-activate verbs are NOT "activate" — never map these to activate_ui_control
@@ -199,7 +213,10 @@ public class PromptFactory implements AiPromptFactory {
     protected Map<String, String> reduce(String rawUserInput) {
         Map<String, String> fullMap = actionsMap.actionMap(isDryRun);
         sttVocabulary = SttCorrector.extractVocabulary(fullMap);
-        String normalizedInput = normalizer.normalize(SttCorrector.correct(rawUserInput, sttVocabulary));
+
+        String corrected = SttCorrector.correct(rawUserInput, sttVocabulary);
+        String normalizedInput = normalizer.normalize(corrected);
+
         return Reducer.reduce(normalizedInput, fullMap, systemSession.conversationalModeOn());
     }
 

--- a/app/src/main/java/elite/intel/ai/brain/i18n/AiActionAliasProvider.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/AiActionAliasProvider.java
@@ -1,0 +1,10 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.Map;
+
+public interface AiActionAliasProvider {
+
+    void addAliases(Map<String, String> map, Status status, boolean isDryRun);
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/AiActionLanguage.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/AiActionLanguage.java
@@ -1,0 +1,8 @@
+package elite.intel.ai.brain.i18n;
+
+public enum AiActionLanguage {
+    EN,
+    RU,
+    UK,
+    DE
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/AiActionLocalizations.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/AiActionLocalizations.java
@@ -1,0 +1,25 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.Map;
+
+public final class AiActionLocalizations {
+
+    private static final AiActionLanguage ACTIVE_LANGUAGE = AiActionLanguage.DE;
+
+    private AiActionLocalizations() {
+    }
+
+    public static void addAliases(Map<String, String> map, Status status, boolean isDryRun) {
+        AiActionAliasProvider provider = switch (ACTIVE_LANGUAGE) {
+            case EN -> new EnglishAiActionAliases();
+            case RU -> new RussianAiActionAliases();
+            case UK -> new UkrainianAiActionAliases();
+            case DE -> new GermanAiActionAliases();
+
+        };
+
+        provider.addAliases(map, status, isDryRun);
+    }
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/EnglishAiActionAliases.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/EnglishAiActionAliases.java
@@ -1,0 +1,234 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static elite.intel.ai.brain.actions.Commands.*;
+import static elite.intel.ai.brain.actions.Queries.*;
+
+public class EnglishAiActionAliases implements AiActionAliasProvider {
+
+    @Override
+    public void addAliases(Map<String, String> map, Status status, boolean isDryRun) {
+
+        // always available
+        map.put("wake up", WAKEUP.getAction());
+        map.put("sleep, go to sleep, ignore me, do not monitor", SLEEP.getAction());
+        map.put("interrupt", INTERRUPT_TTS.getAction());
+
+        // navigation
+        map.put("navigate to coordinates {lat:X, lon:Y}", NAVIGATE_TO_TARGET.getAction());
+        map.put("navigate to active mission, plot route to active mission, plot route to mission, take me to mission, go to mission {key:X}", NAVIGATE_TO_NEXT_MISSION.getAction());
+        map.put("navigate to fleet carrier, go to carrier, head to carrier, return to carrier, take us to carrier", NAVIGATE_TO_CARRIER.getAction());
+        map.put("navigate to landing zone, bearing to landing zone, heading to landing zone, back to LZ", GET_HEADING_TO_LZ.getAction());
+        map.put("navigate to next trade stop, go to next trade stop", NAVIGATE_TO_NEXT_TRADE_STOP.getAction());
+        map.put("navigate from memory, paste from memory", NAVIGATE_TO_ADDRESS_FROM_MEMORY.getAction());
+        map.put("cancel navigation, abort navigation, stop navigation", NAVIGATION_OFF.getAction());
+        map.put("set home system, set current system as home, mark home system", SET_HOME_SYSTEM.getAction());
+        map.put("take me home, go home, navigate home, return home, plot route home, head home, take us home", TAKE_ME_HOME.getAction());
+
+        if (status.isInMainShip() || isDryRun) {
+            // navigation
+            map.put("select fds destination, target destination, set destination, select target destination", TARGET_DESTINATION.getAction());
+            map.put("jump to hyperspace,  jump, hyperspace jump, enter hyperspace, lets go, next way point, let's go", JUMP_TO_HYPERSPACE.getAction());
+            map.put("drop out, drop here, drop ftl, drop from supercruise, leave supercruise, drop in", DROP_FROM_SUPER_CRUISE.getAction());
+            map.put("enter supercruise, supercruise, go supercruise", ENTER_SUPER_CRUISE.getAction());
+            map.put("launch ship, launch, detach from station, leave port, leave station", LAUNCH_SHIP.getAction());
+            // speed / throttle
+            map.put("stop engines, stop here, full stop, all stop, halt, kill engines, cut throttle, zero throttle, stop ship", SET_SPEED_ZERO.getAction());
+            map.put("taxi to landing, taxi, auto land, autopilot landing", TAXI.getAction());
+            map.put("quarter throttle, 25 percent, slow speed, one quarter", SET_SPEED25.getAction());
+            map.put("half throttle, 50 percent, half speed", SET_SPEED50.getAction());
+            map.put("three quarters throttle, 75 percent, three quarter speed", SET_SPEED75.getAction());
+            map.put("full throttle, 100 percent, full speed, maximum speed, max throttle", SET_SPEED100.getAction());
+            map.put("increase speed by {key:X}", INCREASE_SPEED_BY.getAction());
+            map.put("decrease speed by {key:X}", DECREASE_SPEED_BY.getAction());
+            map.put("set optimal speed, optimal approach speed, optimize approach speed", SET_OPTIMAL_SPEED.getAction());
+            map.put("landing gear, gear down, lower landing gear, extend landing gear", DEPLOY_LANDING_GEAR.getAction());
+            map.put("retract landing gear, gear up, raise landing gear, stow landing gear", RETRACT_LANDING_GEAR.getAction());
+            map.put("request docking, dock at station, request landing, docking request, ask for docking, request parking, parking spot, request pad, park ship", REQUEST_DOCKING.getAction());
+            // UI panels
+            map.put("show, open or display fighter panel", SHOW_FIGHTER_PANEL.getAction());
+
+            // combat
+            map.put("deploy hardpoints, weapons hot, combat ready, weapons free, weapons out, arm weapons, weapons ready", DEPLOY_HARDPOINTS.getAction());
+            map.put("retract hardpoints, weapons cold, weapons away, stand down, holster weapons, weapons down, safe weapons", RETRACT_HARDPOINTS.getAction());
+            map.put("target fsd {key:fsd}, target engines {key:drive}, target Power Distributor {key:power distributor} target power plant {key:powerplant}, target powerplant {key:powerplant}, target life support {key:life support}, ", TARGET_SUB_SYSTEM.getAction());
+            map.put("target wingman 1, wingman alpha", TARGET_WINGMAN0.getAction());
+            map.put("target wingman 2, wingman bravo", TARGET_WINGMAN1.getAction());
+            map.put("target wingman 3, wingman charlie", TARGET_WINGMAN2.getAction());
+            map.put("wing nav lock, lock wingman nav, follow wingman", WING_NAV_LOCK.getAction());
+            map.put("priority target, target highest threat, target most dangerous, select hostile, next enemy, select enemy", SELECT_HIGHEST_THREAT.getAction());
+            // vehicle deployment
+            map.put("deploy SRV, deploy vehicle, launch SRV, send out SRV, drop SRV", DEPLOY_SRV.getAction());
+            map.put("deploy heat sink, launch heat sink, dump heat", DEPLOY_HEAT_SINK.getAction());
+            // fighter orders
+            map.put("deploy fighter, launch fighter, send out fighter", DEPLOY_FIGHTER.getAction());
+            map.put("order fighter defend ship, fighter defend, fighter defensive", FIGHTER_REQUEST_DEFENSIVE_BEHAVIOUR.getAction());
+            map.put("order fighter attack my target, fighter attack, sic fighter on target, focus my target, focus target, focus on target, fighter focus target", FIGHTER_REQUEST_FOCUS_TARGET.getAction());
+            map.put("order fighter hold fire, fighter cease fire, fighter stand down", FIGHTER_REQUEST_HOLD_FIRE.getAction());
+            map.put("order fighter return to ship, fighter dock, recall fighter", FIGHTER_REQUEST_REQUEST_DOCK.getAction());
+            map.put("fighter open orders, fire at will, attack at will", FIGHTER_OPEN_ORDERS.getAction());
+        }
+
+        if (status.isInMainShip() && !status.isDocked() || isDryRun) {
+            map.put("stations in system, what stations, nearby stations, star ports, space stations, docking available", QUERY_STATIONS.getAction());
+        }
+
+        if (status.isInSrv() && status.isDocked() || isDryRun) {
+            map.put("show services panel, open services panel, display services panel, show station services panel", SHOW_STATION_SERVICES.getAction());
+        }
+
+        if (status.isInMainShip() || status.isInSrv() || isDryRun) {
+            // flight / ship systems
+            map.put("switch to combat mode", ACTIVATE_COMBAT_MODE.getAction());
+            map.put("switch to analysis mode", ACTIVATE_ANALYSIS_MODE.getAction());
+            map.put("cargo scoop, open cargo scoop, close cargo scoop, deploy cargo scoop, retract cargo scoop, open cargo bay, close cargo bay", TOGGLE_CARGO_SCOOP.getAction());
+            map.put("night vision, nightvision, turn on night vision, turn off night vision {state:true/false}", NIGHT_VISION_ON_OFF.getAction());
+            map.put("headlights, lights, turn off lights, turn on lights, ship lights, lights on, lights off {state:true/false}", LIGHTS_ON_OFF.getAction());
+            // UI panels
+            map.put("show, open or display commander, central, role panel, open knee board", SHOW_COMMANDER_PANEL.getAction());
+            map.put("show, open or display crew panel", SHOW_CREW.getAction());
+            map.put("show, open or display home panel", SHOW_INTERNAL_PANEL.getAction());
+            map.put("show, open or display modules panel", SHOW_MODULES_PANEL.getAction());
+            map.put("show, open or display fire groups", SHOW_FIRE_GROUPS.getAction());
+            map.put("show, open or display inventory panel", SHOW_INVENTORY_PANEL.getAction());
+            map.put("show, open or display storage panel", SHOW_STORAGE_PANEL.getAction());
+            // power
+            map.put("power to shields, max shields, boost shields", INCREASE_SHIELDS_POWER.getAction());
+            map.put("power to engines, max engines, boost engines", INCREASE_ENGINES_POWER.getAction());
+            map.put("power to weapons, max weapons, boost weapons", INCREASE_WEAPONS_POWER.getAction());
+            // vehicle deployment
+            map.put("disembark", DISEMBARK.getAction());
+            map.put("equalize power, balance power, reset power, distribute power equally", RESET_POWER.getAction());
+        }
+
+        if (status.isInSrv() || isDryRun) {
+            map.put("drive assist, driving assist, SRV assist {state:true/false}", DRIVE_ASSIST.getAction());
+            map.put("recover SRV, board ship, return SRV, retrieve SRV, SRV dock", RECOVER_SRV.getAction());
+        }
+
+        if (status.isInSrv() || status.isOnFoot() || isDryRun) {
+            map.put("dismiss ship, send ship away, ship to orbit", DISMISS_SHIP.getAction());
+            map.put("return to surface, pick me up", RETURN_TO_SURFACE.getAction());
+        }
+
+        // market / traders / brokers
+        map.put("find raw material trader, raw trader, where to trade raw materials {key:X}", FIND_RAW_MATERIAL_TRADER.getAction());
+        map.put("find encoded material trader, encoded trader, data trader {key:X}", FIND_ENCODED_MATERIAL_TRADER.getAction());
+        map.put("find manufactured material trader, manufactured trader {key:X}", FIND_MANUFACTURED_MATERIAL_TRADER.getAction());
+        map.put("find human tech broker, human technology broker {key:X}", FIND_HUMAN_TECHNOLOGY_BROKER.getAction());
+        map.put("find guardian tech broker, guardian technology broker {key:X}", FIND_GUARDIAN_TECHNOLOGY_BROKER.getAction());
+        map.put("find commodity, find nearest commodity, buy commodity, where to buy, find market{key:X, max_distance:Y, state:true/false}", FIND_COMMODITY.getAction());
+        map.put("find nearest fleet carrier, nearest carrier", FIND_NEAREST_FLEET_CARRIER.getAction());
+
+        // fleet carrier
+        map.put("set carrier fuel reserve, carrier tritium reserve {key:X}", SET_CARRIER_FUEL_RESERVE.getAction());
+        map.put("calculate fleet carrier route, plan carrier route, carrier jump route", CALCULATE_FLEET_CARRIER_ROUTE.getAction());
+        map.put("enter carrier destination, set carrier destination, carrier destination", ENTER_FLEET_CARRIER_DESTINATION.getAction());
+
+        // trade
+        map.put("calculate trade route", CALCULATE_TRADE_ROUTE.getAction());
+        map.put("list trade route parameters", LIST_TRADE_ROUTE_PARAMETERS.getAction());
+        map.put("monetize route", MONETIZE_ROUTE.getAction());
+
+        map.put("change trade profile starting budget {key:X}", CHANGE_TRADE_PROFILE_SET_STARTING_BUDGET.getAction());
+        map.put("change trade profile max stops {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_NUMBER_OF_STOPS.getAction());
+        map.put("change trade profile max distance {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_DISTANCE_FROM_ENTRY.getAction());
+        map.put("change trade profile allow prohibited cargo {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PROHIBITED_CARGO.getAction());
+        map.put("change trade profile allow planetary port {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PLANETARY_PORT.getAction());
+        map.put("change trade profile allow permit systems {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PERMIT_SYSTEMS.getAction());
+        map.put("change trade profile allow strongholds {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_STRONGHOLDS.getAction());
+
+        // announcements / app settings
+        map.put("toggle radio, radio traffic, radio transmissions {state:true/false}", SET_RADIO_TRANSMISSION_MODE.getAction());
+        map.put("radar contact announcement {state:true/false}", SET_RADAR_CONTACT_ANNOUNCEMENT.getAction());
+        map.put("discovery announcements {state:true/false}", DISCOVERY_ON_OFF.getAction());
+        map.put("route announcements {state:true/false}", ROUTE_ON_OFF.getAction());
+        map.put("disable all announcements", DISABLE_ALL_ANNOUNCEMENTS.getAction());
+        map.put("clear reminders", CLEAR_REMINDERS.getAction());
+        map.put("set reminder {key:X}", SET_REMINDER.getAction());
+
+        // UI panels
+        map.put("activate", ACTIVATE.getAction());
+        map.put("show, open or display transactions panel", SHOW_TRANSACTIONS.getAction());
+        map.put("show, open or display contacts panel", SHOW_CONTACTS.getAction());
+        map.put("show, open or display navigation panel", SHOW_NAVIGATION.getAction());
+        map.put("show, open or display chat panel, comms panel", SHOW_CHAT_PANEL.getAction());
+        map.put("show, open or display email inbox panel, email", SHOW_INBOX_PANEL.getAction());
+        map.put("show, open or display social panel", SHOW_SOCIAL_PANEL.getAction());
+        map.put("show, open or display history panel", SHOW_HISTORY_PANEL.getAction());
+        map.put("show, open or display squadron panel", SHOW_SQUADRON.getAction());
+        map.put("show, open or display status panel", SHOW_STATUS_PANEL.getAction());
+        map.put("show, open or display carrier management panel", DISPLAY_CARRIER_MANAGEMENT.getAction());
+        map.put("show, open or display galaxy map", OPEN_GALAXY_MAP.getAction());
+        map.put("show, open or display local / stat system map", OPEN_SYSTEM_MAP.getAction());
+        map.put("exit close panel", EXIT_CLOSE.getAction());
+
+        // pirate massacre missions
+        map.put("navigate to mission provider system", RECON_PROVIDER_SYSTEM.getAction());
+        map.put("navigate to pirate mission provider", NAVIGATE_TO_PIRATE_MISSION_PROVIDER.getAction());
+        map.put("active missions, current missions, mission log, what missions, mission status, what are our missions, ongoing missions, mission board", ANALYZE_MISSIONS.getAction());
+        map.put("pirate mission, kill count, how many kills, massacre mission progress, kills remaining, massacre progress, pirates remaining, pirate kills, bounty hunt progress", PIRATE_MISSION_PROGRESS.getAction());
+        map.put("find hunting grounds {key:X}", FIND_HUNTING_GROUNDS.getAction());
+        map.put("recon hunting ground, navigate to target system, navigate to hunting ground", RECON_TARGET_SYSTEM.getAction());
+        map.put("ignore hunting ground", IGNORE_HUNTING_GROUND.getAction());
+        map.put("confirm hunting ground, confirm target star system", CONFIRM_HUNTING_GROUND.getAction());
+
+        // science / mining / biology
+        map.put("add mining target {key:X}", ADD_MINING_TARGET.getAction());
+        map.put("remove mining target {key:X}", REMOVE_MINING_TARGET.getAction());
+        map.put("clear mining targets", CLEAR_MINING_TARGETS.getAction());
+        map.put("mining announcements {state:true/false}", MINING_ON_OFF.getAction());
+        map.put("find brain trees {key:X, max_distance:Y}", FIND_BRAIN_TREES.getAction());
+        map.put("find mining site, find mining location, find mining hotspot, find where to mine, find asteroid field {key:X, max_distance:Y}", FIND_MINING_SITE.getAction());
+        map.put("find tritium mining site, find tritium field {key:X, max_distance:Y}", FIND_FLEET_CARRIER_FUEL_MINING_SITE.getAction());
+        map.put("navigate to next bio sample, go to next sample, navigate to next organic, codex entry, navigate to codex entry, navigate to codex", NAVIGATE_TO_NEXT_BIO_SAMPLE.getAction());
+        map.put("scan the system, open fss, full scan, honk, system scan, discovery scan, FSS, full spectrum scan, scan system", OPEN_FSS_AND_SCAN.getAction());
+        map.put("find nearest vista genomics, find genomics, vista genomics", FIND_VISTA_GENOMICS.getAction());
+        map.put("delete codex entry, delete this codex, delete this entry, delete this organic", DELETE_CODEX_ENTRY.getAction());
+
+        map.put("check key bindings, missing key bindings, unbound keys, keyboard bindings, keybind check, missing bindings", KEY_BINDINGS_ANALYSIS.getAction());
+        map.put("bio signals done within the star system, organics scanned in star system, how many bio samples in star system, bio signals in system, bio samples in star system, biological signals in star system, organics in system, which planets have bio signals, which planets still need bio scans, which planets need organic scans, which planets still need scanning, bio scan needed on which planets, planets with unscanned bio signals, bio scan progress", BIO_SAMPLE_IN_STAR_SYSTEM.getAction());
+        map.put("exobiology samples, biology samples, organics at location, what organisms, what's left to scan, remaining organisms, samples left, organisms remaining, exobiology progress, scan remaining, what bio scans completed, what bio scans have we completed, bio scans done, bio scans completed, organics on this planet, biology on this planet, what organisms are here, what organisms are on this planet, bio sample progress on planet, what's been scanned here, what organics do we still have to scan, what organics still to scan, organics still to scan, organics remaining to scan, organics left to scan, what organics remain, biology still to scan, what biology remains, what do we still need to scan here", EXOBIOLOGY_SAMPLES.getAction());
+        map.put("distance to last bio sample, how far to sample, how far to last organism, range to bio sample, how far to previous organism, navigate to bio sample", DISTANCE_TO_LAST_BIO_SAMPLE.getAction());
+        map.put("analyze biome, biome analysis, what biome {key:X}, planetary biome, atmosphere analysis, what life is here, biome type", PLANET_BIOME_ANALYSIS.getAction());
+        map.put("stellar objects, planets in system, landable planets, is planet or moon landable, bodies in system, what planets, how many planets, system bodies, stellar bodies, ice rings, planetary rings, rings in system, has rings, ring system", QUERY_STELLAR_OBJETS.getAction());
+        map.put("signals in system, what signals are in this system, what's in this system, what's detected in system, what signals here, what signals do you see, what signals do you detect, what signals can you see, FSS signals, mining hot spots, resource extraction sites, what signals, conflict zones, emissions, unidentified signals, system signals, detected signals, anomalous signals", QUERY_STELLAR_SIGNALS.getAction());
+        map.put("geo signals, geological signals, volcanic signals, geological activity, volcanic activity, geology in system", QUERY_GEO_SIGNALS.getAction());
+
+        map.put("fleet carriers in system, carriers in system, how many carriers, fleet carriers here, any carriers nearby", QUERY_CARRIERS.getAction());
+        map.put("carrier route, carrier navigation, carrier jump route, carrier trip, carrier journey, carrier travel plan, how many jumps on carrier route, jumps remaining on carrier, carrier route jump count, jumps left on carrier", CARRIER_ROUTE_ANALYSIS.getAction());
+        map.put("carrier route, where is carrier going, carrier next jump, where is carrier headed, carrier heading, carrier endpoint, carrier final destination", CARRIER_ROUTE.getAction());
+        map.put("carrier tritium, carrier fuel, how much tritium, tritium supply, tritium level, carrier fuel level, tritium reserve, carrier tritium status", CARRIER_TRITIUM_SUPPLY.getAction());
+        map.put("carrier status, carrier finances, carrier balance, carrier overview, carrier funds, how long can we operate carrier, carrier fuel status, fleet carrier fuel status, how far can carrier jump, carrier jump range with current tritium, carrier tritium range", CARRIER_STATUS.getAction());
+        map.put("carrier ETA, when does carrier arrive, how long until carrier, carrier arrival time, carrier arrival, when does carrier jump, carrier jump time", CARRIER_ETA.getAction());
+        map.put("distance to carrier, where is our carrier, how far is carrier, where is our carrier, range to carrier, carrier proximity, how far away is carrier", DISTANCE_TO_CARRIER.getAction());
+        map.put("system security, faction control, who controls, power struggle, security level, who owns this system, dominant faction, controlling power", SYSTEM_SECURITY_ANALYSIS.getAction());
+        map.put("trade profile, trade settings, trading parameters, trade configuration, trading criteria", TRADE_PROFILE_ANALYSIS.getAction());
+        map.put("distance to stellar object, how far to body, distance to planet {key:X}, range to planet, how far to moon, how far to station, range to body. NOTE: Sol and Earth always mean the bubble/civilization - never use this action for Sol or Earth", DISTANCE_TO_BODY.getAction());
+        map.put("last scan, what did we scan, last scanned object, most recent scan, latest scan, recent body scan, what did i last scan", LAST_SCAN_ANALYSIS.getAction());
+        map.put("material inventory {key:X}, how many items {key:X}, how many guardian item {key:X}, how much material {key:X}, do we have material {key:X}, how much {key:X} do we have, do we have any {key:X}, engineering material {key:X}, raw material {key:X}, manufactured material {key:X}, encoded material {key:X}, material stock {key:X}", MATERIALS_INVENTORY.getAction());
+        map.put("planet materials, materials here, what materials on this planet, surface materials, what materials are here, material deposits, minerals on planet", PLANET_MATERIALS.getAction());
+        map.put("exploration profits, discovery profits, how much exploration worth, exploration value, scan value, mapping profit, exobiology value, scan earnings, what are scans worth", EXPLORATION_PROFITS.getAction());
+        map.put("query current location, where are we, our position, what system are we in, where am i, our coordinates, current system, what planet are we at, our current position, day length", CURRENT_LOCATION.getAction());
+        map.put("где я нахожусь, где мы находимся, в какой системе я нахожусь, в какой системе мы находимся, какая текущая система, где мой корабль, где мы сейчас, наше местоположение, текущая позиция", CURRENT_LOCATION.getAction());
+        map.put("FSD target info, analyze destination, what star are we targeting, analyze fsd target, information on fsd target", FSD_TARGET_ANALYSIS.getAction());
+        map.put("plotted route, fuel at next stop, fuel availability on route, route analysis, are we there yet, current route, navigation route, jumps remaining, jumps left, how many jumps, next star scoopable, fuel stop", PLOTTED_ROUTE_ANALYSIS.getAction());
+        map.put("trade route, trading route, current trade plan, what are we trading, our trading plan, trading schedule, trade legs", TRADE_ROUTE_ANALYSIS.getAction());
+        map.put("outfitting, ship upgrades, modules available, what modules at station, available modules, available equipment, buy modules, ship parts, station equipment", LOCAL_OUTFITTING.getAction());
+        map.put("shipyard, ships for sale, what ships at station, buy a ship, available ships, ships to buy, new ship", LOCAL_SHIPYARD.getAction());
+        map.put("what is in our cargo hold, what are we carrying, cargo contents, commodities on board, what are we hauling, hold contents", CARGO_HOLD_CONTENTS.getAction());
+        map.put("player profile", PLAYER_PROFILE_ANALYSIS.getAction());
+        map.put("ship loadout, damage report, ship modules, combat readiness report, ship equipment, ship specs, what am I flying, what are we equipped with, do you have, is it equipped, shield generator, hull reinforcement, sensors, thrusters, frameshift, fuel scoop, installed", SHIP_LOADOUT.getAction());
+        map.put("station details, what services here, what services are here, services here, what services does this station have, services at this station, what does station offer, station info, station facilities, what's at this station, services available", STATION_DETAILS.getAction());
+        map.put("на какой станции я нахожусь, на какой станции мы находимся, где я пристыкован, где мы пристыкованы, какая моя текущая станция, какая у нас текущая станция, информация о станции, какие сервисы есть на станции, что есть на этой станции", STATION_DETAILS.getAction());
+        map.put("bounties, total bounties, bounty collected, how much in bounties, bounty earnings, credits from bounties, bounty credits", TOTAL_BOUNTIES.getAction());
+        map.put("distance to bubble, distance to sol, distance from sol, distance to Earth, distance from Earth, how far from sol, how far from bubble, how far from inhabited space, distance from inhabited space, how far from civilization, range from human space", DISTANCE_TO_BUBBLE.getAction());
+        map.put("current time, what time is it, time on earth, galactic time, utc time, what's the time, real time", TIME_IN_ZONE.getAction());
+        map.put("reminder, what was the reminder, destination reminder, any reminders, recall reminder, what did we set as reminder", REMINDER.getAction());
+        map.put("local markets, markets at stations and settlements, markets at outposts in system", ANALYZE_MARKETS.getAction());
+    }
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/GermanAiActionAliases.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/GermanAiActionAliases.java
@@ -1,0 +1,237 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.Map;
+
+import static elite.intel.ai.brain.actions.Commands.*;
+import static elite.intel.ai.brain.actions.Queries.*;
+
+public class GermanAiActionAliases implements AiActionAliasProvider {
+
+    @Override
+    public void addAliases(Map<String, String> map, Status status, boolean isDryRun) {
+        // always available
+        map.put("wach auf, hör zu, hör mir zu, aktiviere dich", WAKEUP.getAction());
+        map.put("schlaf, geh schlafen, ignoriere mich, nicht zuhören, nicht überwachen", SLEEP.getAction());
+        map.put("unterbrich, unterbrechen, sprache stoppen, hör auf zu reden", INTERRUPT_TTS.getAction());
+
+        // navigation
+        map.put("navigiere zu koordinaten {lat:X, lon:Y}, kurs auf koordinaten {lat:X, lon:Y}, fliege zu koordinaten {lat:X, lon:Y}", NAVIGATE_TO_TARGET.getAction());
+        map.put("navigiere zur aktiven mission, route zur aktiven mission planen, route zur mission planen, bring mich zur mission, fliege zur mission {key:X}", NAVIGATE_TO_NEXT_MISSION.getAction());
+        map.put("navigiere zum fleet carrier, fliege zum carrier, kurs zum carrier, zurück zum carrier, bring uns zum carrier, zurück zum träger", NAVIGATE_TO_CARRIER.getAction());
+        map.put("navigiere zur landezone, kurs zur landezone, peilung zur landezone, zurück zur landezone, zurück zur lz", GET_HEADING_TO_LZ.getAction());
+        map.put("navigiere zum nächsten handelsstopp, fliege zum nächsten handelsstopp, nächster handelsstopp", NAVIGATE_TO_NEXT_TRADE_STOP.getAction());
+        map.put("navigiere aus dem speicher, aus speicher einfügen, adresse aus speicher verwenden", NAVIGATE_TO_ADDRESS_FROM_MEMORY.getAction());
+        map.put("navigation abbrechen, route abbrechen, navigation stoppen, route löschen", NAVIGATION_OFF.getAction());
+        map.put("heimatsystem setzen, aktuelles system als heimatsystem setzen, heimatsystem markieren", SET_HOME_SYSTEM.getAction());
+        map.put("bring mich nach hause, fliege nach hause, navigiere nach hause, zurück nach hause, route nach hause planen, kurs nach hause", TAKE_ME_HOME.getAction());
+
+        if (status.isInMainShip() || isDryRun) {
+            // navigation
+            map.put("fsd ziel auswählen, ziel auswählen, ziel setzen, sprungziel auswählen, routenziel auswählen", TARGET_DESTINATION.getAction());
+            map.put("sprung in den hyperraum, spring, hypersprung, hyperraumsprung, in den hyperraum, los gehts, nächster wegpunkt", JUMP_TO_HYPERSPACE.getAction());
+            map.put("aus dem supercruise fallen, hier rausfallen, supercruise verlassen, supercruise beenden, raus hier", DROP_FROM_SUPER_CRUISE.getAction());
+            map.put("in supercruise gehen, supercruise, supercruise aktivieren", ENTER_SUPER_CRUISE.getAction());
+            map.put("schiff starten, starten, abdocken, station verlassen, hafen verlassen", LAUNCH_SHIP.getAction());
+
+            // speed / throttle
+            map.put("triebwerke stoppen, stopp, voller stopp, halt, triebwerke aus, schub auf null, null schub, schiff stoppen", SET_SPEED_ZERO.getAction());
+            map.put("taxi zur landung, taxi, automatisch landen, autopilot landung, autolandung", TAXI.getAction());
+            map.put("viertel schub, fünfundzwanzig prozent, langsame geschwindigkeit, ein viertel", SET_SPEED25.getAction());
+            map.put("halber schub, fünfzig prozent, halbe geschwindigkeit", SET_SPEED50.getAction());
+            map.put("drei viertel schub, fünfundsiebzig prozent, drei viertel geschwindigkeit", SET_SPEED75.getAction());
+            map.put("voller schub, hundert prozent, volle geschwindigkeit, maximale geschwindigkeit, maximum schub", SET_SPEED100.getAction());
+            map.put("geschwindigkeit erhöhen um {key:X}, erhöhe geschwindigkeit um {key:X}, schneller um {key:X}", INCREASE_SPEED_BY.getAction());
+            map.put("geschwindigkeit verringern um {key:X}, reduziere geschwindigkeit um {key:X}, langsamer um {key:X}", DECREASE_SPEED_BY.getAction());
+            map.put("optimale geschwindigkeit setzen, optimale anfluggeschwindigkeit, anfluggeschwindigkeit optimieren", SET_OPTIMAL_SPEED.getAction());
+            map.put("fahrwerk, fahrwerk runter, fahrwerk ausfahren, landegear ausfahren, landefahrwerk ausfahren", DEPLOY_LANDING_GEAR.getAction());
+            map.put("fahrwerk einfahren, fahrwerk hoch, fahrwerk rein, landefahrwerk einfahren", RETRACT_LANDING_GEAR.getAction());
+            map.put("landeerlaubnis anfragen, andocken anfragen, docking anfragen, landung anfragen, parkplatz anfragen, landeplatz anfragen", REQUEST_DOCKING.getAction());
+
+            // UI panels
+            map.put("jäger panel anzeigen, jäger panel öffnen, fighter panel öffnen", SHOW_FIGHTER_PANEL.getAction());
+
+            // combat
+            map.put("waffen ausfahren, hardpoints ausfahren, waffen heiß, kampfbereit, waffen bereit, bewaffnen", DEPLOY_HARDPOINTS.getAction());
+            map.put("waffen einfahren, hardpoints einfahren, waffen kalt, waffen weg, zurücktreten, waffen sichern", RETRACT_HARDPOINTS.getAction());
+            map.put("ziel fsd {key:fsd}, ziel triebwerke {key:drive}, ziel energieverteiler {key:power distributor}, ziel kraftwerk {key:powerplant}, ziel lebenserhaltung {key:life support}", TARGET_SUB_SYSTEM.getAction());
+            map.put("wingman eins anvisieren, wingman alpha", TARGET_WINGMAN0.getAction());
+            map.put("wingman zwei anvisieren, wingman bravo", TARGET_WINGMAN1.getAction());
+            map.put("wingman drei anvisieren, wingman charlie", TARGET_WINGMAN2.getAction());
+            map.put("wing nav lock, navigationsbindung zum wingman, wingman folgen", WING_NAV_LOCK.getAction());
+            map.put("höchste bedrohung anvisieren, gefährlichstes ziel, feind auswählen, nächster feind, prioritätsziel", SELECT_HIGHEST_THREAT.getAction());
+
+            // vehicle deployment
+            map.put("srv ausfahren, srv starten, fahrzeug ausfahren, fahrzeug deployen, srv deployen", DEPLOY_SRV.getAction());
+            map.put("heat sink abwerfen, kühlkörper auslösen, wärmesenke starten, hitze abwerfen", DEPLOY_HEAT_SINK.getAction());
+
+            // fighter orders
+            map.put("jäger starten, jäger aussetzen, fighter starten, fighter deployen", DEPLOY_FIGHTER.getAction());
+            map.put("jäger verteidige das schiff, fighter defensiv, jäger defensiv", FIGHTER_REQUEST_DEFENSIVE_BEHAVIOUR.getAction());
+            map.put("jäger greife mein ziel an, fighter greif mein ziel an, fokus auf mein ziel, ziel fokussieren", FIGHTER_REQUEST_FOCUS_TARGET.getAction());
+            map.put("jäger feuer einstellen, fighter feuer halten, feuer einstellen", FIGHTER_REQUEST_HOLD_FIRE.getAction());
+            map.put("jäger zurück zum schiff, fighter andocken, jäger zurückrufen", FIGHTER_REQUEST_REQUEST_DOCK.getAction());
+            map.put("jäger feuer frei, fighter feuer frei, nach eigenem ermessen angreifen", FIGHTER_OPEN_ORDERS.getAction());
+        }
+
+        if (status.isInMainShip() && !status.isDocked() || isDryRun) {
+            map.put("stationen im system, welche stationen, nahe stationen, raumhäfen, space stations, andocken möglich", QUERY_STATIONS.getAction());
+        }
+
+        if (status.isInSrv() && status.isDocked() || isDryRun) {
+            map.put("services panel anzeigen, service panel öffnen, stationsdienste anzeigen, stationsservice öffnen", SHOW_STATION_SERVICES.getAction());
+        }
+
+        if (status.isInMainShip() || status.isInSrv() || isDryRun) {
+            // flight / ship systems
+            map.put("in den kampfmodus wechseln, kampfmodus aktivieren", ACTIVATE_COMBAT_MODE.getAction());
+            map.put("in den analysemodus wechseln, analysemodus aktivieren", ACTIVATE_ANALYSIS_MODE.getAction());
+            map.put("frachtschaufel, frachtschaufel öffnen, frachtschaufel schließen, cargo scoop öffnen, cargo scoop schließen, frachtluke öffnen, frachtluke schließen", TOGGLE_CARGO_SCOOP.getAction());
+            map.put("nachtsicht, nachsicht an, nachsicht aus, nachtsicht einschalten, nachtsicht ausschalten {state:true/false}", NIGHT_VISION_ON_OFF.getAction());
+            map.put("scheinwerfer, licht, lichter, licht einschalten, licht ausschalten, schiffslicht, lichter an, lichter aus {state:true/false}", LIGHTS_ON_OFF.getAction());
+
+            // UI panels
+            map.put("commander panel anzeigen, commander panel öffnen, zentrales panel, rollen panel, kneeboard öffnen", SHOW_COMMANDER_PANEL.getAction());
+            map.put("crew panel anzeigen, crew panel öffnen, besatzung anzeigen", SHOW_CREW.getAction());
+            map.put("home panel anzeigen, internes panel öffnen, heim panel öffnen", SHOW_INTERNAL_PANEL.getAction());
+            map.put("module panel anzeigen, module öffnen, module anzeigen", SHOW_MODULES_PANEL.getAction());
+            map.put("feuergruppen anzeigen, feuergruppen öffnen, fire groups öffnen", SHOW_FIRE_GROUPS.getAction());
+            map.put("inventar anzeigen, inventar öffnen", SHOW_INVENTORY_PANEL.getAction());
+            map.put("lager anzeigen, storage panel öffnen, speicher öffnen", SHOW_STORAGE_PANEL.getAction());
+
+            // power
+            map.put("energie auf schilde, maximale schilde, schilde verstärken", INCREASE_SHIELDS_POWER.getAction());
+            map.put("energie auf triebwerke, maximale triebwerke, triebwerke verstärken", INCREASE_ENGINES_POWER.getAction());
+            map.put("energie auf waffen, maximale waffen, waffen verstärken", INCREASE_WEAPONS_POWER.getAction());
+
+            // vehicle deployment
+            map.put("aussteigen, schiff verlassen, von bord gehen", DISEMBARK.getAction());
+            map.put("energie ausgleichen, energie balancieren, energie zurücksetzen, energie gleichmäßig verteilen", RESET_POWER.getAction());
+        }
+
+        if (status.isInSrv() || isDryRun) {
+            map.put("fahrassistenz, drive assist, srv assist {state:true/false}", DRIVE_ASSIST.getAction());
+            map.put("srv bergen, zurück ins schiff, srv zurückholen, srv andocken", RECOVER_SRV.getAction());
+        }
+
+        if (status.isInSrv() || status.isOnFoot() || isDryRun) {
+            map.put("schiff wegschicken, schiff in den orbit, schiff fortschicken", DISMISS_SHIP.getAction());
+            map.put("zur oberfläche zurückkehren, hol mich ab, schiff zurückrufen", RETURN_TO_SURFACE.getAction());
+        }
+
+        // market / traders / brokers
+        map.put("rohmaterialhändler finden, raw material trader finden, wo rohmaterialien tauschen {key:X}", FIND_RAW_MATERIAL_TRADER.getAction());
+        map.put("datenhändler finden, encoded material trader finden, encoded trader, wo daten tauschen {key:X}", FIND_ENCODED_MATERIAL_TRADER.getAction());
+        map.put("hergestellte materialien händler finden, manufactured material trader finden, manufactured trader {key:X}", FIND_MANUFACTURED_MATERIAL_TRADER.getAction());
+        map.put("human tech broker finden, menschlichen technologiebroker finden {key:X}", FIND_HUMAN_TECHNOLOGY_BROKER.getAction());
+        map.put("guardian tech broker finden, guardian technologiebroker finden, wächter tech broker {key:X}", FIND_GUARDIAN_TECHNOLOGY_BROKER.getAction());
+        map.put("ware finden, nächste ware finden, ware kaufen, wo kaufen, markt finden {key:X, max_distance:Y, state:true/false}", FIND_COMMODITY.getAction());
+        map.put("nächsten fleet carrier finden, nächsten carrier finden, nächsten träger finden", FIND_NEAREST_FLEET_CARRIER.getAction());
+
+        // fleet carrier
+        map.put("carrier treibstoffreserve setzen, carrier tritium reserve setzen {key:X}", SET_CARRIER_FUEL_RESERVE.getAction());
+        map.put("fleet carrier route berechnen, carrier route planen, carrier sprungroute planen", CALCULATE_FLEET_CARRIER_ROUTE.getAction());
+        map.put("carrier ziel eingeben, carrier ziel setzen, carrier ziel", ENTER_FLEET_CARRIER_DESTINATION.getAction());
+
+        // trade
+        map.put("handelsroute berechnen, trade route berechnen", CALCULATE_TRADE_ROUTE.getAction());
+        map.put("handelsroutenparameter auflisten, handelsparameter anzeigen", LIST_TRADE_ROUTE_PARAMETERS.getAction());
+        map.put("route monetarisieren, route gewinn berechnen, route profit berechnen", MONETIZE_ROUTE.getAction());
+
+        map.put("handelsprofil startbudget ändern {key:X}, startbudget handelsprofil ändern {key:X}", CHANGE_TRADE_PROFILE_SET_STARTING_BUDGET.getAction());
+        map.put("handelsprofil maximale stopps ändern {key:X}, max stopps handelsprofil ändern {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_NUMBER_OF_STOPS.getAction());
+        map.put("handelsprofil maximale entfernung ändern {key:X}, max entfernung handelsprofil ändern {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_DISTANCE_FROM_ENTRY.getAction());
+        map.put("verbotene waren im handelsprofil erlauben {state:true/false}, illegale ware erlauben {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PROHIBITED_CARGO.getAction());
+        map.put("planetare häfen im handelsprofil erlauben {state:true/false}, planetenhäfen erlauben {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PLANETARY_PORT.getAction());
+        map.put("permit systeme im handelsprofil erlauben {state:true/false}, erlaubnissysteme erlauben {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PERMIT_SYSTEMS.getAction());
+        map.put("strongholds im handelsprofil erlauben {state:true/false}, festungen erlauben {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_STRONGHOLDS.getAction());
+
+        // announcements / app settings
+        map.put("radio umschalten, funktrafik, funkübertragungen {state:true/false}", SET_RADIO_TRANSMISSION_MODE.getAction());
+        map.put("radarkontakt ansagen {state:true/false}, radar kontakt ansage {state:true/false}", SET_RADAR_CONTACT_ANNOUNCEMENT.getAction());
+        map.put("entdeckungsansagen {state:true/false}, discovery ansagen {state:true/false}", DISCOVERY_ON_OFF.getAction());
+        map.put("routenansagen {state:true/false}, route ansagen {state:true/false}", ROUTE_ON_OFF.getAction());
+        map.put("alle ansagen deaktivieren, alle meldungen ausschalten", DISABLE_ALL_ANNOUNCEMENTS.getAction());
+        map.put("erinnerungen löschen, erinnerungen zurücksetzen", CLEAR_REMINDERS.getAction());
+        map.put("erinnerung setzen {key:X}, erinnere mich {key:X}", SET_REMINDER.getAction());
+
+        // UI panels
+        map.put("aktivieren, aktiviere", ACTIVATE.getAction());
+        map.put("transaktionen anzeigen, transaktionspanel öffnen", SHOW_TRANSACTIONS.getAction());
+        map.put("kontakte anzeigen, kontakte öffnen, kontaktpanel öffnen", SHOW_CONTACTS.getAction());
+        map.put("navigation anzeigen, navigationspanel öffnen", SHOW_NAVIGATION.getAction());
+        map.put("chat anzeigen, chat öffnen, comms panel öffnen, kommunikation öffnen", SHOW_CHAT_PANEL.getAction());
+        map.put("posteingang anzeigen, inbox öffnen, e-mail öffnen, nachrichten öffnen", SHOW_INBOX_PANEL.getAction());
+        map.put("social panel anzeigen, sozial panel öffnen", SHOW_SOCIAL_PANEL.getAction());
+        map.put("verlauf anzeigen, history panel öffnen, historie anzeigen", SHOW_HISTORY_PANEL.getAction());
+        map.put("staffel anzeigen, squadron panel öffnen, squadron anzeigen", SHOW_SQUADRON.getAction());
+        map.put("status anzeigen, status panel öffnen", SHOW_STATUS_PANEL.getAction());
+        map.put("carrier management anzeigen, trägerverwaltung öffnen, carrier verwaltung öffnen", DISPLAY_CARRIER_MANAGEMENT.getAction());
+        map.put("galaxiekarte öffnen, galaxiekarte anzeigen, galaxy map öffnen", OPEN_GALAXY_MAP.getAction());
+        map.put("systemkarte öffnen, lokale karte öffnen, system map öffnen", OPEN_SYSTEM_MAP.getAction());
+        map.put("panel schließen, schließen, raus, verlassen", EXIT_CLOSE.getAction());
+
+        // pirate massacre missions
+        map.put("navigiere zum missionsgeber system, kurs zum system des missionsgebers", RECON_PROVIDER_SYSTEM.getAction());
+        map.put("navigiere zum piraten missionsgeber, fliege zum piraten missionsgeber", NAVIGATE_TO_PIRATE_MISSION_PROVIDER.getAction());
+        map.put("aktive missionen, aktuelle missionen, missionslog, welche missionen, missionsstatus, unsere missionen, laufende missionen", ANALYZE_MISSIONS.getAction());
+        map.put("piratenmission, kill count, wie viele kills, massacre mission fortschritt, verbleibende kills, verbleibende piraten, piraten kills", PIRATE_MISSION_PROGRESS.getAction());
+        map.put("jagdgebiet finden {key:X}, hunting grounds finden {key:X}, ort zum jagen finden {key:X}", FIND_HUNTING_GROUNDS.getAction());
+        map.put("jagdgebiet erkunden, zum zielsystem navigieren, zum jagdgebiet navigieren", RECON_TARGET_SYSTEM.getAction());
+        map.put("jagdgebiet ignorieren, hunting ground ignorieren", IGNORE_HUNTING_GROUND.getAction());
+        map.put("jagdgebiet bestätigen, zielsystem bestätigen", CONFIRM_HUNTING_GROUND.getAction());
+
+        // science / mining / biology
+        map.put("mining ziel hinzufügen {key:X}, abbauziel hinzufügen {key:X}", ADD_MINING_TARGET.getAction());
+        map.put("mining ziel entfernen {key:X}, abbauziel entfernen {key:X}", REMOVE_MINING_TARGET.getAction());
+        map.put("mining ziele löschen, abbauziele löschen", CLEAR_MINING_TARGETS.getAction());
+        map.put("mining ansagen {state:true/false}, abbau ansagen {state:true/false}", MINING_ON_OFF.getAction());
+        map.put("brain trees finden {key:X, max_distance:Y}, gehirnbäume finden {key:X, max_distance:Y}", FIND_BRAIN_TREES.getAction());
+        map.put("mining site finden, mining ort finden, hotspot finden, wo abbauen, asteroidenfeld finden {key:X, max_distance:Y}", FIND_MINING_SITE.getAction());
+        map.put("tritium mining site finden, tritium feld finden, tritium hotspot finden {key:X, max_distance:Y}", FIND_FLEET_CARRIER_FUEL_MINING_SITE.getAction());
+        map.put("zum nächsten bio sample navigieren, zur nächsten probe, zum nächsten organismus, codex eintrag, zum codex eintrag navigieren", NAVIGATE_TO_NEXT_BIO_SAMPLE.getAction());
+        map.put("system scannen, fss öffnen, vollständiger scan, honk, discovery scan, full spectrum scan, systemscan", OPEN_FSS_AND_SCAN.getAction());
+        map.put("nächste vista genomics finden, vista genomics finden, genomics finden", FIND_VISTA_GENOMICS.getAction());
+        map.put("codex eintrag löschen, diesen codex löschen, diesen eintrag löschen, diesen organismus löschen", DELETE_CODEX_ENTRY.getAction());
+
+        map.put("key bindings prüfen, fehlende tastenbelegung, unbelegte tasten, tastaturbelegung, bindings prüfen, fehlende bindings", KEY_BINDINGS_ANALYSIS.getAction());
+        map.put("bio signale im system erledigt, organik im system gescannt, wie viele bio samples im system, bio signale im system, welche planeten haben biosignale, welche planeten müssen noch gescannt werden, bio scan fortschritt", BIO_SAMPLE_IN_STAR_SYSTEM.getAction());
+        map.put("exobiologie proben, biologische proben, organische proben am ort, welche organismen, was bleibt zu scannen, verbleibende organismen, exobiologie fortschritt, was wurde hier gescannt, organik auf diesem planeten", EXOBIOLOGY_SAMPLES.getAction());
+        map.put("entfernung zur letzten bio probe, wie weit zur probe, entfernung zum letzten organismus, reichweite zur bio probe, zur bio probe navigieren", DISTANCE_TO_LAST_BIO_SAMPLE.getAction());
+        map.put("biom analysieren, biom analyse, welches biom {key:X}, planetenbiom, atmosphärenanalyse, welches leben ist hier, biom typ", PLANET_BIOME_ANALYSIS.getAction());
+        map.put("stellare objekte, planeten im system, landbare planeten, ist planet oder mond landbar, körper im system, welche planeten, wie viele planeten, systemkörper, ringe, eisringe", QUERY_STELLAR_OBJETS.getAction());
+        map.put("signale im system, welche signale sind im system, was ist im system, was wurde erkannt, fss signale, mining hotspots, resource extraction sites, konfliktzonen, emissionen, unbekannte signale", QUERY_STELLAR_SIGNALS.getAction());
+        map.put("geosignale, geologische signale, vulkanische signale, geologische aktivität, vulkanische aktivität", QUERY_GEO_SIGNALS.getAction());
+
+        map.put("fleet carrier im system, carrier im system, wie viele carrier, träger im system, carrier in der nähe", QUERY_CARRIERS.getAction());
+        map.put("carrier route, carrier navigation, carrier sprungroute, carrier reise, wie viele sprünge auf der carrier route, verbleibende carrier sprünge", CARRIER_ROUTE_ANALYSIS.getAction());
+        map.put("carrier route, wohin fliegt der carrier, nächster carrier sprung, wohin ist der carrier unterwegs, carrier ziel, endziel des carriers", CARRIER_ROUTE.getAction());
+        map.put("carrier tritium, carrier treibstoff, wie viel tritium, tritium vorrat, tritium stand, carrier fuel level", CARRIER_TRITIUM_SUPPLY.getAction());
+        map.put("carrier status, carrier finanzen, carrier balance, carrier übersicht, carrier kontostand, wie lange kann der carrier betrieben werden, carrier reichweite", CARRIER_STATUS.getAction());
+        map.put("carrier eta, wann kommt der carrier an, wie lange bis carrier ankunft, carrier ankunft, wann springt der carrier, carrier sprungzeit", CARRIER_ETA.getAction());
+        map.put("entfernung zum carrier, wo ist unser carrier, wie weit ist der carrier weg, distanz zum carrier, carrier nähe", DISTANCE_TO_CARRIER.getAction());
+        map.put("systemsicherheit, fraktionskontrolle, wer kontrolliert das system, sicherheitsstufe, wem gehört das system, dominante fraktion, kontrollierende macht", SYSTEM_SECURITY_ANALYSIS.getAction());
+        map.put("handelsprofil, handelseinstellungen, handelsparameter, handelskonfiguration, handelskriterien", TRADE_PROFILE_ANALYSIS.getAction());
+        map.put("entfernung zum stellaren objekt, wie weit zum körper, entfernung zum planeten {key:X}, entfernung zum mond, wie weit zur station, distanz zum körper", DISTANCE_TO_BODY.getAction());
+        map.put("letzter scan, was haben wir gescannt, zuletzt gescanntes objekt, jüngster scan, aktueller scan", LAST_SCAN_ANALYSIS.getAction());
+        map.put("material inventar {key:X}, wie viele items {key:X}, wie viel material {key:X}, haben wir material {key:X}, wie viel {key:X} haben wir, engineering material {key:X}, rohmaterial {key:X}, manufactured material {key:X}, encoded material {key:X}", MATERIALS_INVENTORY.getAction());
+        map.put("planetenmaterialien, materialien hier, welche materialien auf diesem planeten, oberflächenmaterialien, materialvorkommen, mineralien auf dem planeten", PLANET_MATERIALS.getAction());
+        map.put("explorationsgewinn, entdeckungsgewinn, wie viel ist exploration wert, scan wert, kartierungsgewinn, exobiologie wert", EXPLORATION_PROFITS.getAction());
+        map.put("aktueller standort, wo sind wir, unsere position, in welchem system sind wir, wo bin ich, unsere koordinaten, aktuelles system, auf welchem planeten sind wir, aktuelle position, tageslänge", CURRENT_LOCATION.getAction());
+        map.put("fsd ziel info, ziel analysieren, welchen stern visieren wir an, fsd ziel analysieren, information zum fsd ziel", FSD_TARGET_ANALYSIS.getAction());
+        map.put("geplante route, treibstoff am nächsten stopp, treibstoffverfügbarkeit auf der route, routenanalyse, sind wir schon da, aktuelle route, wie viele sprünge übrig, nächste tankbare sonne", PLOTTED_ROUTE_ANALYSIS.getAction());
+        map.put("handelsroute, aktuelle handelsroute, aktueller handelsplan, womit handeln wir, unser handelsplan, handelsabschnitte", TRADE_ROUTE_ANALYSIS.getAction());
+        map.put("outfitting, schiffsupgrades, verfügbare module, welche module auf station, verfügbare ausrüstung, module kaufen, schiffsteile", LOCAL_OUTFITTING.getAction());
+        map.put("werft, schiffe zum verkauf, welche schiffe auf station, schiff kaufen, verfügbare schiffe, neues schiff", LOCAL_SHIPYARD.getAction());
+        map.put("was ist im frachtraum, was tragen wir, frachtinhalt, waren an bord, was transportieren wir, laderaum inhalt", CARGO_HOLD_CONTENTS.getAction());
+        map.put("spielerprofil, commander profil, kommandantenprofil", PLAYER_PROFILE_ANALYSIS.getAction());
+        map.put("schiff loadout, schadensbericht, schiffsmodule, kampfbereitschaft, schiffsausrüstung, schiffsdaten, was fliege ich, was ist ausgerüstet, schildgenerator, hüllenverstärkung, sensoren, triebwerke, frameshift, fuelscoop", SHIP_LOADOUT.getAction());
+        map.put("stationsdetails, welche services hier, welche dienste hier, services auf station, was bietet die station, stationsinfo, stationseinrichtungen, was gibt es auf dieser station, verfügbare services", STATION_DETAILS.getAction());
+        map.put("kopfgelder, gesamte kopfgelder, bounty gesammelt, wie viel kopfgeld, bounty ertrag, credits aus kopfgeldern", TOTAL_BOUNTIES.getAction());
+        map.put("entfernung zur bubble, entfernung zu sol, entfernung von sol, entfernung zur erde, wie weit von sol, wie weit von der bubble, wie weit von zivilisation, entfernung vom bewohnten raum", DISTANCE_TO_BUBBLE.getAction());
+        map.put("aktuelle zeit, wie spät ist es, zeit auf der erde, galaktische zeit, utc zeit, echte zeit", TIME_IN_ZONE.getAction());
+        map.put("erinnerung, was war die erinnerung, ziel erinnerung, gibt es erinnerungen, welche erinnerung haben wir gesetzt", REMINDER.getAction());
+        map.put("lokale märkte, märkte auf stationen und siedlungen, märkte auf außenposten im system", ANALYZE_MARKETS.getAction());
+    }
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/RussianAiActionAliases.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/RussianAiActionAliases.java
@@ -1,0 +1,237 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.Map;
+
+import static elite.intel.ai.brain.actions.Commands.*;
+import static elite.intel.ai.brain.actions.Queries.*;
+
+public class RussianAiActionAliases implements AiActionAliasProvider {
+
+    @Override
+    public void addAliases(Map<String, String> map, Status status, boolean isDryRun) {
+        // always available
+        map.put("проснись, слушай, слушай меня, активируйся", WAKEUP.getAction());
+        map.put("спи, усни, иди спать, игнорируй меня, не слушай, не отслеживай", SLEEP.getAction());
+        map.put("перебей, прерви, останови речь, прекрати говорить", INTERRUPT_TTS.getAction());
+
+        // navigation
+        map.put("лети к координатам {lat:X, lon:Y}, навигация к координатам {lat:X, lon:Y}, курс на координаты {lat:X, lon:Y}", NAVIGATE_TO_TARGET.getAction());
+        map.put("навигация к активной миссии, проложи маршрут к активной миссии, проложи маршрут к миссии, веди к миссии, лети к миссии {key:X}", NAVIGATE_TO_NEXT_MISSION.getAction());
+        map.put("лети к авианосцу, навигация к авианосцу, курс к авианосцу, вернись к авианосцу, веди нас к авианосцу", NAVIGATE_TO_CARRIER.getAction());
+        map.put("навигация к зоне посадки, курс к зоне посадки, азимут к зоне посадки, обратно к зоне посадки", GET_HEADING_TO_LZ.getAction());
+        map.put("навигация к следующей торговой остановке, лети к следующей торговой точке", NAVIGATE_TO_NEXT_TRADE_STOP.getAction());
+        map.put("навигация из памяти, вставь из памяти, используй адрес из памяти", NAVIGATE_TO_ADDRESS_FROM_MEMORY.getAction());
+        map.put("отмени навигацию, прерви навигацию, останови навигацию, сбрось маршрут", NAVIGATION_OFF.getAction());
+        map.put("установи домашнюю систему, сделай текущую систему домашней, отметь домашнюю систему", SET_HOME_SYSTEM.getAction());
+        map.put("веди домой, лети домой, навигация домой, вернись домой, проложи маршрут домой, курс домой", TAKE_ME_HOME.getAction());
+
+        if (status.isInMainShip() || isDryRun) {
+            // navigation
+            map.put("выбери fsd пункт назначения, выбери пункт назначения, установи пункт назначения, выбери цель маршрута", TARGET_DESTINATION.getAction());
+            map.put("прыжок в гиперпространство, прыгай, гиперпрыжок, войти в гиперпространство, поехали, следующий маршрутный пункт", JUMP_TO_HYPERSPACE.getAction());
+            map.put("выйти из суперкруиза, выйти здесь, сбросить суперкруиз, выйти из сверхсвета, сбросься здесь", DROP_FROM_SUPER_CRUISE.getAction());
+            map.put("войти в суперкруиз, суперкруиз, включи суперкруиз", ENTER_SUPER_CRUISE.getAction());
+            map.put("запусти корабль, старт, отстыковаться, покинуть станцию, выйти из порта", LAUNCH_SHIP.getAction());
+
+            // speed / throttle
+            map.put("останови двигатели, стоп, полный стоп, остановись, заглуши двигатели, сбрось тягу, нулевая тяга, останови корабль", SET_SPEED_ZERO.getAction());
+            map.put("такси к посадке, такси, автопосадка, автоматическая посадка", TAXI.getAction());
+            map.put("четверть тяги, двадцать пять процентов, малая скорость, одна четверть", SET_SPEED25.getAction());
+            map.put("половина тяги, пятьдесят процентов, половина скорости", SET_SPEED50.getAction());
+            map.put("три четверти тяги, семьдесят пять процентов, три четверти скорости", SET_SPEED75.getAction());
+            map.put("полная тяга, сто процентов, полный ход, максимальная скорость, максимум тяги", SET_SPEED100.getAction());
+            map.put("увеличь скорость на {key:X}, прибавь скорость на {key:X}", INCREASE_SPEED_BY.getAction());
+            map.put("уменьши скорость на {key:X}, сбавь скорость на {key:X}", DECREASE_SPEED_BY.getAction());
+            map.put("установи оптимальную скорость, оптимальная скорость подхода, оптимизируй скорость подхода", SET_OPTIMAL_SPEED.getAction());
+            map.put("шасси, шасси вниз, выпусти шасси, опусти посадочное шасси", DEPLOY_LANDING_GEAR.getAction());
+            map.put("убери шасси, шасси вверх, подними шасси, сложи посадочное шасси", RETRACT_LANDING_GEAR.getAction());
+            map.put("запроси стыковку, стыковка со станцией, запроси посадку, запрос посадки, запроси парковку, попроси площадку", REQUEST_DOCKING.getAction());
+
+            // UI panels
+            map.put("покажи панель истребителя, открой панель истребителя, отобрази панель истребителя", SHOW_FIGHTER_PANEL.getAction());
+
+            // combat
+            map.put("выпусти оружие, оружие к бою, боевой режим, оружие свободно, вооружиться, подготовить оружие", DEPLOY_HARDPOINTS.getAction());
+            map.put("убери оружие, оружие убрать, снять оружие, выйти из боя, спрячь оружие, безопасный режим оружия", RETRACT_HARDPOINTS.getAction());
+            map.put("цель fsd {key:fsd}, цель двигатели {key:drive}, цель распределитель питания {key:power distributor}, цель силовая установка {key:powerplant}, цель жизнеобеспечение {key:life support}", TARGET_SUB_SYSTEM.getAction());
+            map.put("цель ведомый один, ведомый альфа", TARGET_WINGMAN0.getAction());
+            map.put("цель ведомый два, ведомый браво", TARGET_WINGMAN1.getAction());
+            map.put("цель ведомый три, ведомый чарли", TARGET_WINGMAN2.getAction());
+            map.put("навигационная привязка крыла, привязка к ведомому, следовать за ведомым", WING_NAV_LOCK.getAction());
+            map.put("приоритетная цель, цель с наибольшей угрозой, самая опасная цель, выбрать врага, следующий враг", SELECT_HIGHEST_THREAT.getAction());
+
+            // vehicle deployment
+            map.put("выпусти срв, запусти срв, выпусти транспорт, высади срв", DEPLOY_SRV.getAction());
+            map.put("выпусти теплоотвод, запусти теплоотвод, сбрось тепло", DEPLOY_HEAT_SINK.getAction());
+
+            // fighter orders
+            map.put("выпусти истребитель, запусти истребитель, отправь истребитель", DEPLOY_FIGHTER.getAction());
+            map.put("истребитель защищай корабль, истребитель оборона, приказ истребителю обороняться", FIGHTER_REQUEST_DEFENSIVE_BEHAVIOUR.getAction());
+            map.put("истребитель атакуй мою цель, истребитель атаковать, фокус на цель, сосредоточься на цели", FIGHTER_REQUEST_FOCUS_TARGET.getAction());
+            map.put("истребитель прекратить огонь, истребитель не стрелять, держать огонь", FIGHTER_REQUEST_HOLD_FIRE.getAction());
+            map.put("истребитель вернись на корабль, истребитель стыковка, отозвать истребитель", FIGHTER_REQUEST_REQUEST_DOCK.getAction());
+            map.put("истребитель свободный огонь, огонь по готовности, атаковать по усмотрению", FIGHTER_OPEN_ORDERS.getAction());
+        }
+
+        if (status.isInMainShip() && !status.isDocked() || isDryRun) {
+            map.put("станции в системе, какие станции, ближайшие станции, космопорты, космические станции, доступна ли стыковка", QUERY_STATIONS.getAction());
+        }
+
+        if (status.isInSrv() && status.isDocked() || isDryRun) {
+            map.put("покажи панель сервисов, открой панель сервисов, отобрази панель сервисов станции", SHOW_STATION_SERVICES.getAction());
+        }
+
+        if (status.isInMainShip() || status.isInSrv() || isDryRun) {
+            // flight / ship systems
+            map.put("переключись в боевой режим, включи боевой режим", ACTIVATE_COMBAT_MODE.getAction());
+            map.put("переключись в режим анализа, включи режим анализа", ACTIVATE_ANALYSIS_MODE.getAction());
+            map.put("грузовой ковш, открой грузовой ковш, закрой грузовой ковш, выпусти грузовой ковш, убери грузовой ковш, открой грузовой люк, закрой грузовой люк", TOGGLE_CARGO_SCOOP.getAction());
+            map.put("ночное видение, включи ночное видение, выключи ночное видение {state:true/false}", NIGHT_VISION_ON_OFF.getAction());
+            map.put("фары, свет, выключи свет, включи свет, корабельный свет, свет включить, свет выключить {state:true/false}", LIGHTS_ON_OFF.getAction());
+
+            // UI panels
+            map.put("покажи панель командира, открой центральную панель, открой панель ролей, открой планшет", SHOW_COMMANDER_PANEL.getAction());
+            map.put("покажи панель экипажа, открой панель экипажа", SHOW_CREW.getAction());
+            map.put("покажи домашнюю панель, открой внутреннюю панель", SHOW_INTERNAL_PANEL.getAction());
+            map.put("покажи панель модулей, открой модули", SHOW_MODULES_PANEL.getAction());
+            map.put("покажи огневые группы, открой огневые группы", SHOW_FIRE_GROUPS.getAction());
+            map.put("покажи инвентарь, открой инвентарь", SHOW_INVENTORY_PANEL.getAction());
+            map.put("покажи хранилище, открой склад, открой хранилище", SHOW_STORAGE_PANEL.getAction());
+
+            // power
+            map.put("энергию на щиты, максимум щитов, усилить щиты", INCREASE_SHIELDS_POWER.getAction());
+            map.put("энергию на двигатели, максимум двигателей, усилить двигатели", INCREASE_ENGINES_POWER.getAction());
+            map.put("энергию на оружие, максимум оружия, усилить оружие", INCREASE_WEAPONS_POWER.getAction());
+
+            // vehicle deployment
+            map.put("выйти из корабля, высадиться, покинуть корабль", DISEMBARK.getAction());
+            map.put("сбалансируй энергию, баланс энергии, сбрось распределение энергии, распределить энергию поровну", RESET_POWER.getAction());
+        }
+
+        if (status.isInSrv() || isDryRun) {
+            map.put("помощь вождения, ассистент вождения, ассистент срв {state:true/false}", DRIVE_ASSIST.getAction());
+            map.put("вернуть срв, на борт корабля, вернуться в корабль, забрать срв, стыковка срв", RECOVER_SRV.getAction());
+        }
+
+        if (status.isInSrv() || status.isOnFoot() || isDryRun) {
+            map.put("отправь корабль, корабль на орбиту, отозвать корабль с поверхности", DISMISS_SHIP.getAction());
+            map.put("вернись на поверхность, забери меня, вызови корабль", RETURN_TO_SURFACE.getAction());
+        }
+
+        // market / traders / brokers
+        map.put("найди торговца сырьевыми материалами, сырьевой торговец, где обменять сырьевые материалы {key:X}", FIND_RAW_MATERIAL_TRADER.getAction());
+        map.put("найди торговца закодированными материалами, торговец данными, где обменять данные {key:X}", FIND_ENCODED_MATERIAL_TRADER.getAction());
+        map.put("найди торговца произведенными материалами, торговец manufactured материалами {key:X}", FIND_MANUFACTURED_MATERIAL_TRADER.getAction());
+        map.put("найди человеческого техноброкера, человеческий технологический брокер {key:X}", FIND_HUMAN_TECHNOLOGY_BROKER.getAction());
+        map.put("найди guardian техноброкера, технологический брокер стражей {key:X}", FIND_GUARDIAN_TECHNOLOGY_BROKER.getAction());
+        map.put("найди товар, найди ближайший товар, купить товар, где купить, найди рынок {key:X, max_distance:Y, state:true/false}", FIND_COMMODITY.getAction());
+        map.put("найди ближайший авианосец, ближайший carrier, ближайший флиткэрриер", FIND_NEAREST_FLEET_CARRIER.getAction());
+
+        // fleet carrier
+        map.put("установи резерв топлива авианосца, резерв трития авианосца {key:X}", SET_CARRIER_FUEL_RESERVE.getAction());
+        map.put("рассчитай маршрут авианосца, спланируй маршрут авианосца, маршрут прыжков авианосца", CALCULATE_FLEET_CARRIER_ROUTE.getAction());
+        map.put("введи пункт назначения авианосца, установи пункт назначения авианосца, направление авианосца", ENTER_FLEET_CARRIER_DESTINATION.getAction());
+
+        // trade
+        map.put("рассчитай торговый маршрут, торговый маршрут", CALCULATE_TRADE_ROUTE.getAction());
+        map.put("покажи параметры торгового маршрута, список параметров торговли", LIST_TRADE_ROUTE_PARAMETERS.getAction());
+        map.put("монетизируй маршрут, оцени прибыль маршрута", MONETIZE_ROUTE.getAction());
+
+        map.put("измени стартовый бюджет торгового профиля {key:X}", CHANGE_TRADE_PROFILE_SET_STARTING_BUDGET.getAction());
+        map.put("измени максимальное число остановок торгового профиля {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_NUMBER_OF_STOPS.getAction());
+        map.put("измени максимальное расстояние торгового профиля {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_DISTANCE_FROM_ENTRY.getAction());
+        map.put("разрешить запрещенные товары в торговом профиле {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PROHIBITED_CARGO.getAction());
+        map.put("разрешить планетарные порты в торговом профиле {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PLANETARY_PORT.getAction());
+        map.put("разрешить системы с разрешением в торговом профиле {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PERMIT_SYSTEMS.getAction());
+        map.put("разрешить strongholds в торговом профиле {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_STRONGHOLDS.getAction());
+
+        // announcements / app settings
+        map.put("переключи радио, радиотрафик, радиопередачи {state:true/false}", SET_RADIO_TRANSMISSION_MODE.getAction());
+        map.put("объявления радарных контактов {state:true/false}", SET_RADAR_CONTACT_ANNOUNCEMENT.getAction());
+        map.put("объявления открытий {state:true/false}", DISCOVERY_ON_OFF.getAction());
+        map.put("объявления маршрута {state:true/false}", ROUTE_ON_OFF.getAction());
+        map.put("отключи все объявления, выключи все уведомления", DISABLE_ALL_ANNOUNCEMENTS.getAction());
+        map.put("очисти напоминания, сбрось напоминания", CLEAR_REMINDERS.getAction());
+        map.put("установи напоминание {key:X}, напомни {key:X}", SET_REMINDER.getAction());
+
+        // UI panels
+        map.put("активировать, активируй", ACTIVATE.getAction());
+        map.put("покажи панель транзакций, открой транзакции", SHOW_TRANSACTIONS.getAction());
+        map.put("покажи панель контактов, открой контакты", SHOW_CONTACTS.getAction());
+        map.put("покажи панель навигации, открой навигацию", SHOW_NAVIGATION.getAction());
+        map.put("покажи чат, открой чат, панель связи, коммс панель", SHOW_CHAT_PANEL.getAction());
+        map.put("покажи почту, открой входящие, email", SHOW_INBOX_PANEL.getAction());
+        map.put("покажи социальную панель, открой социальную панель", SHOW_SOCIAL_PANEL.getAction());
+        map.put("покажи историю, открой историю", SHOW_HISTORY_PANEL.getAction());
+        map.put("покажи эскадрилью, открой эскадрилью", SHOW_SQUADRON.getAction());
+        map.put("покажи статус, открой панель статуса", SHOW_STATUS_PANEL.getAction());
+        map.put("покажи управление авианосцем, открой carrier management", DISPLAY_CARRIER_MANAGEMENT.getAction());
+        map.put("открой карту галактики, покажи карту галактики", OPEN_GALAXY_MAP.getAction());
+        map.put("открой карту системы, покажи локальную карту, системная карта", OPEN_SYSTEM_MAP.getAction());
+        map.put("закрыть панель, выйти, закрыть", EXIT_CLOSE.getAction());
+
+        // pirate massacre missions
+        map.put("навигация к системе выдачи миссий, курс к системе провайдера миссий", RECON_PROVIDER_SYSTEM.getAction());
+        map.put("навигация к пиратскому провайдеру миссий, лети к выдаче пиратских миссий", NAVIGATE_TO_PIRATE_MISSION_PROVIDER.getAction());
+        map.put("активные миссии, текущие миссии, журнал миссий, какие миссии, статус миссий, наши миссии", ANALYZE_MISSIONS.getAction());
+        map.put("пиратская миссия, счет убийств, сколько убийств, прогресс massacre миссии, сколько пиратов осталось", PIRATE_MISSION_PROGRESS.getAction());
+        map.put("найди охотничьи угодья {key:X}, найди место охоты {key:X}", FIND_HUNTING_GROUNDS.getAction());
+        map.put("разведка охотничьих угодий, навигация к целевой системе, курс к системе охоты", RECON_TARGET_SYSTEM.getAction());
+        map.put("игнорируй охотничьи угодья, пропусти место охоты", IGNORE_HUNTING_GROUND.getAction());
+        map.put("подтверди охотничьи угодья, подтверди целевую систему", CONFIRM_HUNTING_GROUND.getAction());
+
+        // science / mining / biology
+        map.put("добавь цель добычи {key:X}", ADD_MINING_TARGET.getAction());
+        map.put("удали цель добычи {key:X}", REMOVE_MINING_TARGET.getAction());
+        map.put("очисти цели добычи", CLEAR_MINING_TARGETS.getAction());
+        map.put("объявления добычи {state:true/false}", MINING_ON_OFF.getAction());
+        map.put("найди мозговые деревья {key:X, max_distance:Y}", FIND_BRAIN_TREES.getAction());
+        map.put("найди место добычи, найди точку добычи, найди hotspot, где майнить, найди астероидное поле {key:X, max_distance:Y}", FIND_MINING_SITE.getAction());
+        map.put("найди место добычи трития, найди тритиевое поле {key:X, max_distance:Y}", FIND_FLEET_CARRIER_FUEL_MINING_SITE.getAction());
+        map.put("навигация к следующему биосэмплу, к следующему образцу, к следующей органике, запись кодекса, навигация к кодексу", NAVIGATE_TO_NEXT_BIO_SAMPLE.getAction());
+        map.put("просканируй систему, открой fss, полный скан, хонк, скан системы, full spectrum scan", OPEN_FSS_AND_SCAN.getAction());
+        map.put("найди ближайшую vista genomics, найди геномику", FIND_VISTA_GENOMICS.getAction());
+        map.put("удали запись кодекса, удали этот кодекс, удали эту запись, удали эту органику", DELETE_CODEX_ENTRY.getAction());
+
+        map.put("проверь бинды, отсутствующие клавиши, неназначенные клавиши, клавиатурные привязки, проверка клавиш", KEY_BINDINGS_ANALYSIS.getAction());
+        map.put("биосигналы в системе выполнены, органика просканирована в системе, сколько биосэмплов в системе, биосигналы в системе, какие планеты имеют биосигналы, какие планеты еще нужно сканировать", BIO_SAMPLE_IN_STAR_SYSTEM.getAction());
+        map.put("экзобиологические образцы, биологические образцы, органика в локации, какие организмы, что осталось сканировать, оставшиеся организмы, прогресс экзобиологии, что просканировано здесь, какая органика на этой планете", EXOBIOLOGY_SAMPLES.getAction());
+        map.put("расстояние до последнего биосэмпла, как далеко до образца, расстояние до последней органики, дистанция до биосэмпла, навигация к биосэмплу", DISTANCE_TO_LAST_BIO_SAMPLE.getAction());
+        map.put("анализ биома, какой биом {key:X}, планетарный биом, анализ атмосферы, какая жизнь здесь, тип биома", PLANET_BIOME_ANALYSIS.getAction());
+        map.put("звездные объекты, планеты в системе, посадочные планеты, планета или луна пригодна для посадки, тела в системе, какие планеты, сколько планет, кольца, ледяные кольца", QUERY_STELLAR_OBJETS.getAction());
+        map.put("сигналы в системе, какие сигналы в системе, что есть в системе, обнаруженные сигналы, fss сигналы, hotspots, resource extraction sites, конфликтные зоны, эмиссии", QUERY_STELLAR_SIGNALS.getAction());
+        map.put("геосигналы, геологические сигналы, вулканические сигналы, геологическая активность, вулканическая активность", QUERY_GEO_SIGNALS.getAction());
+
+        map.put("авианосцы в системе, carriers в системе, сколько авианосцев, есть ли авианосцы рядом", QUERY_CARRIERS.getAction());
+        map.put("маршрут авианосца, навигация авианосца, путь авианосца, сколько прыжков на маршруте авианосца, прыжков осталось", CARRIER_ROUTE_ANALYSIS.getAction());
+        map.put("маршрут авианосца, куда летит авианосец, следующий прыжок авианосца, конечная точка авианосца", CARRIER_ROUTE.getAction());
+        map.put("тритий авианосца, топливо авианосца, сколько трития, уровень трития, резерв трития", CARRIER_TRITIUM_SUPPLY.getAction());
+        map.put("статус авианосца, финансы авианосца, баланс авианосца, обзор авианосца, средства авианосца, сколько авианосец может работать, запас хода авианосца", CARRIER_STATUS.getAction());
+        map.put("eta авианосца, когда прибудет авианосец, сколько до прибытия авианосца, время прыжка авианосца", CARRIER_ETA.getAction());
+        map.put("расстояние до авианосца, где наш авианосец, как далеко авианосец, дистанция до авианосца", DISTANCE_TO_CARRIER.getAction());
+        map.put("безопасность системы, контроль фракции, кто контролирует систему, уровень безопасности, владелец системы, доминирующая фракция", SYSTEM_SECURITY_ANALYSIS.getAction());
+        map.put("торговый профиль, торговые настройки, параметры торговли, торговая конфигурация, критерии торговли", TRADE_PROFILE_ANALYSIS.getAction());
+        map.put("расстояние до звездного объекта, как далеко до тела, расстояние до планеты {key:X}, расстояние до луны, как далеко до станции, дистанция до тела", DISTANCE_TO_BODY.getAction());
+        map.put("последний скан, что мы сканировали, последний просканированный объект, самый свежий скан", LAST_SCAN_ANALYSIS.getAction());
+        map.put("инвентарь материалов {key:X}, сколько предметов {key:X}, сколько материалов {key:X}, есть ли материал {key:X}, сколько {key:X} у нас есть, инженерный материал {key:X}, сырьевой материал {key:X}, manufactured материал {key:X}, закодированный материал {key:X}", MATERIALS_INVENTORY.getAction());
+        map.put("материалы планеты, материалы здесь, какие материалы на этой планете, поверхностные материалы, залежи материалов, минералы на планете", PLANET_MATERIALS.getAction());
+        map.put("прибыль исследования, стоимость открытий, сколько стоит исследование, ценность сканов, прибыль картографирования, ценность экзобиологии", EXPLORATION_PROFITS.getAction());
+        map.put("где я нахожусь, где мы находимся, наша позиция, в какой системе мы, где я, наши координаты, текущая система, на какой планете мы, текущая позиция, длина дня", CURRENT_LOCATION.getAction());
+        map.put("информация о цели fsd, анализ пункта назначения, какую звезду мы выбрали, анализ fsd цели", FSD_TARGET_ANALYSIS.getAction());
+        map.put("проложенный маршрут, топливо на следующей остановке, наличие топлива на маршруте, анализ маршрута, мы уже на месте, текущий маршрут, сколько прыжков осталось, следующая звезда scoopable", PLOTTED_ROUTE_ANALYSIS.getAction());
+        map.put("торговый маршрут, текущий торговый план, чем мы торгуем, наш торговый план, торговые этапы", TRADE_ROUTE_ANALYSIS.getAction());
+        map.put("оснащение, улучшения корабля, доступные модули, какие модули на станции, доступное оборудование, купить модули, части корабля", LOCAL_OUTFITTING.getAction());
+        map.put("верфь, корабли на продажу, какие корабли на станции, купить корабль, доступные корабли, новый корабль", LOCAL_SHIPYARD.getAction());
+        map.put("что в грузовом отсеке, что мы везем, содержимое груза, товары на борту, чем мы загружены", CARGO_HOLD_CONTENTS.getAction());
+        map.put("профиль игрока", PLAYER_PROFILE_ANALYSIS.getAction());
+        map.put("компоновка корабля, отчет о повреждениях, модули корабля, готовность к бою, оборудование корабля, характеристики корабля, на чем я лечу, что установлено, генератор щитов, усиление корпуса, сенсоры, двигатели, frameshift, топливный ковш", SHIP_LOADOUT.getAction());
+        map.put("детали станции, какие сервисы здесь, какие услуги здесь, сервисы на станции, что предлагает станция, информация о станции, оборудование станции, что есть на этой станции, доступные сервисы", STATION_DETAILS.getAction());
+        map.put("награды за головы, общий bounty, сколько bounty, заработок с bounty, кредиты за bounty", TOTAL_BOUNTIES.getAction());
+        map.put("расстояние до пузыря, расстояние до sol, расстояние от sol, расстояние до земли, как далеко от пузыря, как далеко от цивилизации, расстояние от населенного космоса", DISTANCE_TO_BUBBLE.getAction());
+        map.put("текущее время, сколько времени, время на земле, галактическое время, utc время, реальное время", TIME_IN_ZONE.getAction());
+        map.put("напоминание, какое было напоминание, напоминание пункта назначения, есть ли напоминания, что мы установили как напоминание", REMINDER.getAction());
+        map.put("локальные рынки, рынки на станциях и поселениях, рынки на аванпостах в системе", ANALYZE_MARKETS.getAction());
+    }
+}

--- a/app/src/main/java/elite/intel/ai/brain/i18n/UkrainianAiActionAliases.java
+++ b/app/src/main/java/elite/intel/ai/brain/i18n/UkrainianAiActionAliases.java
@@ -1,0 +1,237 @@
+package elite.intel.ai.brain.i18n;
+
+import elite.intel.session.Status;
+
+import java.util.Map;
+
+import static elite.intel.ai.brain.actions.Commands.*;
+import static elite.intel.ai.brain.actions.Queries.*;
+
+public class UkrainianAiActionAliases implements AiActionAliasProvider {
+
+    @Override
+    public void addAliases(Map<String, String> map, Status status, boolean isDryRun) {
+        // always available
+        map.put("прокинься, слухай, слухай мене, активуйся", WAKEUP.getAction());
+        map.put("спи, засни, йди спати, ігноруй мене, не слухай, не відстежуй", SLEEP.getAction());
+        map.put("перебий, перерви, зупини мову, припини говорити", INTERRUPT_TTS.getAction());
+
+        // navigation
+        map.put("лети до координат {lat:X, lon:Y}, навігація до координат {lat:X, lon:Y}, курс на координати {lat:X, lon:Y}", NAVIGATE_TO_TARGET.getAction());
+        map.put("навігація до активної місії, проклади маршрут до активної місії, проклади маршрут до місії, веди до місії, лети до місії {key:X}", NAVIGATE_TO_NEXT_MISSION.getAction());
+        map.put("лети до авіаносця, навігація до авіаносця, курс до авіаносця, повернись до авіаносця, веди нас до авіаносця", NAVIGATE_TO_CARRIER.getAction());
+        map.put("навігація до зони посадки, курс до зони посадки, азимут до зони посадки, назад до зони посадки", GET_HEADING_TO_LZ.getAction());
+        map.put("навігація до наступної торгової зупинки, лети до наступної торгової точки", NAVIGATE_TO_NEXT_TRADE_STOP.getAction());
+        map.put("навігація з пам'яті, встав із пам'яті, використай адресу з пам'яті", NAVIGATE_TO_ADDRESS_FROM_MEMORY.getAction());
+        map.put("скасуй навігацію, перерви навігацію, зупини навігацію, скинь маршрут", NAVIGATION_OFF.getAction());
+        map.put("встанови домашню систему, зроби поточну систему домашньою, познач домашню систему", SET_HOME_SYSTEM.getAction());
+        map.put("веди додому, лети додому, навігація додому, повернись додому, проклади маршрут додому, курс додому", TAKE_ME_HOME.getAction());
+
+        if (status.isInMainShip() || isDryRun) {
+            // navigation
+            map.put("вибери fsd пункт призначення, вибери пункт призначення, встанови пункт призначення, вибери ціль маршруту", TARGET_DESTINATION.getAction());
+            map.put("стрибок у гіперпростір, стрибай, гіперстрибок, увійти в гіперпростір, поїхали, наступна точка маршруту", JUMP_TO_HYPERSPACE.getAction());
+            map.put("вийти із суперкруїзу, вийди тут, скинути суперкруїз, вийти зі надсвітла, скинься тут", DROP_FROM_SUPER_CRUISE.getAction());
+            map.put("увійти в суперкруїз, суперкруїз, увімкни суперкруїз", ENTER_SUPER_CRUISE.getAction());
+            map.put("запусти корабель, старт, відстикуватись, покинути станцію, вийти з порту", LAUNCH_SHIP.getAction());
+
+            // speed / throttle
+            map.put("зупини двигуни, стоп, повний стоп, зупинись, заглуши двигуни, скинь тягу, нульова тяга, зупини корабель", SET_SPEED_ZERO.getAction());
+            map.put("таксі до посадки, таксі, автопосадка, автоматична посадка", TAXI.getAction());
+            map.put("чверть тяги, двадцять п'ять відсотків, мала швидкість, одна чверть", SET_SPEED25.getAction());
+            map.put("половина тяги, п'ятдесят відсотків, половина швидкості", SET_SPEED50.getAction());
+            map.put("три чверті тяги, сімдесят п'ять відсотків, три чверті швидкості", SET_SPEED75.getAction());
+            map.put("повна тяга, сто відсотків, повний хід, максимальна швидкість, максимум тяги", SET_SPEED100.getAction());
+            map.put("збільш швидкість на {key:X}, додай швидкість на {key:X}", INCREASE_SPEED_BY.getAction());
+            map.put("зменш швидкість на {key:X}, знизь швидкість на {key:X}", DECREASE_SPEED_BY.getAction());
+            map.put("встанови оптимальну швидкість, оптимальна швидкість підходу, оптимізуй швидкість підходу", SET_OPTIMAL_SPEED.getAction());
+            map.put("шасі, шасі вниз, випусти шасі, опусти посадкове шасі", DEPLOY_LANDING_GEAR.getAction());
+            map.put("прибери шасі, шасі вгору, підніми шасі, склади посадкове шасі", RETRACT_LANDING_GEAR.getAction());
+            map.put("запроси стикування, стикування зі станцією, запроси посадку, запит посадки, попроси паркування, запроси майданчик", REQUEST_DOCKING.getAction());
+
+            // UI panels
+            map.put("покажи панель винищувача, відкрий панель винищувача, відобрази панель винищувача", SHOW_FIGHTER_PANEL.getAction());
+
+            // combat
+            map.put("випусти зброю, зброю до бою, бойова готовність, зброя вільна, озброїтись, підготувати зброю", DEPLOY_HARDPOINTS.getAction());
+            map.put("прибери зброю, зброю прибрати, сховай зброю, вийти з бою, безпечний режим зброї", RETRACT_HARDPOINTS.getAction());
+            map.put("ціль fsd {key:fsd}, ціль двигуни {key:drive}, ціль розподільник живлення {key:power distributor}, ціль силова установка {key:powerplant}, ціль життєзабезпечення {key:life support}", TARGET_SUB_SYSTEM.getAction());
+            map.put("ціль напарник один, напарник альфа", TARGET_WINGMAN0.getAction());
+            map.put("ціль напарник два, напарник браво", TARGET_WINGMAN1.getAction());
+            map.put("ціль напарник три, напарник чарлі", TARGET_WINGMAN2.getAction());
+            map.put("навігаційна прив'язка крила, прив'язка до напарника, слідувати за напарником", WING_NAV_LOCK.getAction());
+            map.put("пріоритетна ціль, ціль з найбільшою загрозою, найнебезпечніша ціль, вибрати ворога, наступний ворог", SELECT_HIGHEST_THREAT.getAction());
+
+            // vehicle deployment
+            map.put("випусти срв, запусти срв, випусти транспорт, висади срв", DEPLOY_SRV.getAction());
+            map.put("випусти тепловідвід, запусти тепловідвід, скинь тепло", DEPLOY_HEAT_SINK.getAction());
+
+            // fighter orders
+            map.put("випусти винищувач, запусти винищувач, відправ винищувач", DEPLOY_FIGHTER.getAction());
+            map.put("винищувач захищай корабель, винищувач оборона, наказ винищувачу оборонятись", FIGHTER_REQUEST_DEFENSIVE_BEHAVIOUR.getAction());
+            map.put("винищувач атакуй мою ціль, винищувач атакувати, фокус на ціль, зосередься на цілі", FIGHTER_REQUEST_FOCUS_TARGET.getAction());
+            map.put("винищувач припинити вогонь, винищувач не стріляти, тримати вогонь", FIGHTER_REQUEST_HOLD_FIRE.getAction());
+            map.put("винищувач повернись на корабель, винищувач стикування, відкликати винищувач", FIGHTER_REQUEST_REQUEST_DOCK.getAction());
+            map.put("винищувач вільний вогонь, вогонь за готовністю, атакувати на власний розсуд", FIGHTER_OPEN_ORDERS.getAction());
+        }
+
+        if (status.isInMainShip() && !status.isDocked() || isDryRun) {
+            map.put("станції в системі, які станції, найближчі станції, космопорти, космічні станції, чи доступне стикування", QUERY_STATIONS.getAction());
+        }
+
+        if (status.isInSrv() && status.isDocked() || isDryRun) {
+            map.put("покажи панель сервісів, відкрий панель сервісів, відобрази панель сервісів станції", SHOW_STATION_SERVICES.getAction());
+        }
+
+        if (status.isInMainShip() || status.isInSrv() || isDryRun) {
+            // flight / ship systems
+            map.put("перемкнись у бойовий режим, увімкни бойовий режим", ACTIVATE_COMBAT_MODE.getAction());
+            map.put("перемкнись у режим аналізу, увімкни режим аналізу", ACTIVATE_ANALYSIS_MODE.getAction());
+            map.put("вантажний ківш, відкрий вантажний ківш, закрий вантажний ківш, випусти вантажний ківш, прибери вантажний ківш, відкрий вантажний люк, закрий вантажний люк", TOGGLE_CARGO_SCOOP.getAction());
+            map.put("нічне бачення, увімкни нічне бачення, вимкни нічне бачення {state:true/false}", NIGHT_VISION_ON_OFF.getAction());
+            map.put("фари, світло, вимкни світло, увімкни світло, корабельне світло, світло увімкнути, світло вимкнути {state:true/false}", LIGHTS_ON_OFF.getAction());
+
+            // UI panels
+            map.put("покажи панель командира, відкрий центральну панель, відкрий панель ролей, відкрий планшет", SHOW_COMMANDER_PANEL.getAction());
+            map.put("покажи панель екіпажу, відкрий панель екіпажу", SHOW_CREW.getAction());
+            map.put("покажи домашню панель, відкрий внутрішню панель", SHOW_INTERNAL_PANEL.getAction());
+            map.put("покажи панель модулів, відкрий модулі", SHOW_MODULES_PANEL.getAction());
+            map.put("покажи вогневі групи, відкрий вогневі групи", SHOW_FIRE_GROUPS.getAction());
+            map.put("покажи інвентар, відкрий інвентар", SHOW_INVENTORY_PANEL.getAction());
+            map.put("покажи сховище, відкрий склад, відкрий сховище", SHOW_STORAGE_PANEL.getAction());
+
+            // power
+            map.put("енергію на щити, максимум щитів, посилити щити", INCREASE_SHIELDS_POWER.getAction());
+            map.put("енергію на двигуни, максимум двигунів, посилити двигуни", INCREASE_ENGINES_POWER.getAction());
+            map.put("енергію на зброю, максимум зброї, посилити зброю", INCREASE_WEAPONS_POWER.getAction());
+
+            // vehicle deployment
+            map.put("вийти з корабля, висадитися, покинути корабель", DISEMBARK.getAction());
+            map.put("збалансуй енергію, баланс енергії, скинь розподіл енергії, розподілити енергію порівну", RESET_POWER.getAction());
+        }
+
+        if (status.isInSrv() || isDryRun) {
+            map.put("допомога керування, асистент керування, асистент срв {state:true/false}", DRIVE_ASSIST.getAction());
+            map.put("повернути срв, на борт корабля, повернутися в корабель, забрати срв, стикування срв", RECOVER_SRV.getAction());
+        }
+
+        if (status.isInSrv() || status.isOnFoot() || isDryRun) {
+            map.put("відправ корабель, корабель на орбіту, відкликати корабель з поверхні", DISMISS_SHIP.getAction());
+            map.put("повернись на поверхню, забери мене, виклич корабель", RETURN_TO_SURFACE.getAction());
+        }
+
+        // market / traders / brokers
+        map.put("знайди торговця сировиною, торговець raw матеріалами, де обміняти raw матеріали {key:X}", FIND_RAW_MATERIAL_TRADER.getAction());
+        map.put("знайди торговця закодованими матеріалами, encoded trader, торговець даними {key:X}", FIND_ENCODED_MATERIAL_TRADER.getAction());
+        map.put("знайди торговця виготовленими матеріалами, manufactured trader, торговець manufactured матеріалами {key:X}", FIND_MANUFACTURED_MATERIAL_TRADER.getAction());
+        map.put("знайди людського техноброкера, human tech broker {key:X}", FIND_HUMAN_TECHNOLOGY_BROKER.getAction());
+        map.put("знайди guardian техноброкера, guardian technology broker {key:X}", FIND_GUARDIAN_TECHNOLOGY_BROKER.getAction());
+        map.put("знайди товар, знайди найближчий товар, купити товар, де купити, знайди ринок {key:X, max_distance:Y, state:true/false}", FIND_COMMODITY.getAction());
+        map.put("знайди найближчий авіаносець, найближчий carrier", FIND_NEAREST_FLEET_CARRIER.getAction());
+
+        // fleet carrier
+        map.put("встанови резерв палива авіаносця, резерв тритію авіаносця {key:X}", SET_CARRIER_FUEL_RESERVE.getAction());
+        map.put("розрахуй маршрут авіаносця, сплануй маршрут авіаносця, маршрут стрибків авіаносця", CALCULATE_FLEET_CARRIER_ROUTE.getAction());
+        map.put("введи пункт призначення авіаносця, встанови пункт призначення авіаносця, пункт призначення авіаносця", ENTER_FLEET_CARRIER_DESTINATION.getAction());
+
+        // trade
+        map.put("розрахуй торговий маршрут", CALCULATE_TRADE_ROUTE.getAction());
+        map.put("список параметрів торгового маршруту, покажи параметри торгового маршруту", LIST_TRADE_ROUTE_PARAMETERS.getAction());
+        map.put("монетизуй маршрут, зроби маршрут прибутковим", MONETIZE_ROUTE.getAction());
+
+        map.put("змінити стартовий бюджет торгового профілю {key:X}", CHANGE_TRADE_PROFILE_SET_STARTING_BUDGET.getAction());
+        map.put("змінити максимальну кількість зупинок торгового профілю {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_NUMBER_OF_STOPS.getAction());
+        map.put("змінити максимальну відстань від входу торгового профілю {key:X}", CHANGE_TRADE_PROFILE_SET_MAX_DISTANCE_FROM_ENTRY.getAction());
+        map.put("змінити торговий профіль дозволити заборонений вантаж {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PROHIBITED_CARGO.getAction());
+        map.put("змінити торговий профіль дозволити планетарний порт {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PLANETARY_PORT.getAction());
+        map.put("змінити торговий профіль дозволити системи з дозволом {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_PERMIT_SYSTEMS.getAction());
+        map.put("змінити торговий профіль дозволити strongholds {state:true/false}", CHANGE_TRADE_PROFILE_SET_ALLOW_STRONGHOLDS.getAction());
+
+        // announcements / app settings
+        map.put("перемкни радіо, радіотрафік, радіопередачі {state:true/false}", SET_RADIO_TRANSMISSION_MODE.getAction());
+        map.put("оголошення радарних контактів {state:true/false}", SET_RADAR_CONTACT_ANNOUNCEMENT.getAction());
+        map.put("оголошення відкриттів {state:true/false}", DISCOVERY_ON_OFF.getAction());
+        map.put("оголошення маршруту {state:true/false}", ROUTE_ON_OFF.getAction());
+        map.put("вимкни всі оголошення", DISABLE_ALL_ANNOUNCEMENTS.getAction());
+        map.put("очисти нагадування", CLEAR_REMINDERS.getAction());
+        map.put("встанови нагадування {key:X}", SET_REMINDER.getAction());
+
+        // UI panels
+        map.put("активуй, натисни активувати", ACTIVATE.getAction());
+        map.put("покажи панель транзакцій, відкрий транзакції", SHOW_TRANSACTIONS.getAction());
+        map.put("покажи контакти, відкрий панель контактів", SHOW_CONTACTS.getAction());
+        map.put("покажи панель навігації, відкрий навігацію", SHOW_NAVIGATION.getAction());
+        map.put("покажи чат, відкрий чат, панель зв'язку, коммс панель", SHOW_CHAT_PANEL.getAction());
+        map.put("покажи пошту, відкрий вхідні, email", SHOW_INBOX_PANEL.getAction());
+        map.put("покажи соціальну панель, відкрий соціальну панель", SHOW_SOCIAL_PANEL.getAction());
+        map.put("покажи історію, відкрий історію", SHOW_HISTORY_PANEL.getAction());
+        map.put("покажи ескадрилью, відкрий ескадрилью", SHOW_SQUADRON.getAction());
+        map.put("покажи статус, відкрий панель статусу", SHOW_STATUS_PANEL.getAction());
+        map.put("покажи керування авіаносцем, відкрий carrier management", DISPLAY_CARRIER_MANAGEMENT.getAction());
+        map.put("відкрий карту галактики, покажи карту галактики", OPEN_GALAXY_MAP.getAction());
+        map.put("відкрий карту системи, покажи локальну карту, системна карта", OPEN_SYSTEM_MAP.getAction());
+        map.put("закрий панель, вийти, закрити", EXIT_CLOSE.getAction());
+
+        // pirate massacre missions
+        map.put("навігація до системи видачі місій, курс до системи провайдера місій", RECON_PROVIDER_SYSTEM.getAction());
+        map.put("навігація до піратського провайдера місій, лети до видачі піратських місій", NAVIGATE_TO_PIRATE_MISSION_PROVIDER.getAction());
+        map.put("активні місії, поточні місії, журнал місій, які місії, статус місій, наші місії", ANALYZE_MISSIONS.getAction());
+        map.put("піратська місія, рахунок вбивств, скільки вбивств, прогрес massacre місії, скільки піратів залишилось", PIRATE_MISSION_PROGRESS.getAction());
+        map.put("знайди мисливські угіддя {key:X}, знайди місце полювання {key:X}", FIND_HUNTING_GROUNDS.getAction());
+        map.put("розвідка мисливських угідь, навігація до цільової системи, курс до системи полювання", RECON_TARGET_SYSTEM.getAction());
+        map.put("ігноруй мисливські угіддя, пропусти місце полювання", IGNORE_HUNTING_GROUND.getAction());
+        map.put("підтверди мисливські угіддя, підтверди цільову зоряну систему", CONFIRM_HUNTING_GROUND.getAction());
+
+        // science / mining / biology
+        map.put("додай ціль видобутку {key:X}", ADD_MINING_TARGET.getAction());
+        map.put("видали ціль видобутку {key:X}", REMOVE_MINING_TARGET.getAction());
+        map.put("очисти цілі видобутку", CLEAR_MINING_TARGETS.getAction());
+        map.put("оголошення видобутку {state:true/false}", MINING_ON_OFF.getAction());
+        map.put("знайди мозкові дерева {key:X, max_distance:Y}", FIND_BRAIN_TREES.getAction());
+        map.put("знайди місце видобутку, знайди точку видобутку, знайди hotspot, де майнити, знайди астероїдне поле {key:X, max_distance:Y}", FIND_MINING_SITE.getAction());
+        map.put("знайди місце видобутку тритію, знайди тритієве поле {key:X, max_distance:Y}", FIND_FLEET_CARRIER_FUEL_MINING_SITE.getAction());
+        map.put("навігація до наступного біозразка, до наступного зразка, до наступної органіки, запис кодексу, навігація до кодексу", NAVIGATE_TO_NEXT_BIO_SAMPLE.getAction());
+        map.put("проскануй систему, відкрий fss, повний скан, honk, скан системи, full spectrum scan", OPEN_FSS_AND_SCAN.getAction());
+        map.put("знайди найближчу vista genomics, знайди геноміку", FIND_VISTA_GENOMICS.getAction());
+        map.put("видали запис кодексу, видали цей кодекс, видали цей запис, видали цю органіку", DELETE_CODEX_ENTRY.getAction());
+
+        map.put("перевір бинди, відсутні клавіші, неназначені клавіші, клавіатурні прив'язки, перевірка клавіш", KEY_BINDINGS_ANALYSIS.getAction());
+        map.put("біосигнали в системі виконані, органіка просканована в системі, скільки біозразків у системі, біосигнали в системі, які планети мають біосигнали, які планети ще треба сканувати", BIO_SAMPLE_IN_STAR_SYSTEM.getAction());
+        map.put("екзобіологічні зразки, біологічні зразки, органіка в локації, які організми, що залишилось сканувати, організми залишились, прогрес екзобіології, що проскановано тут, яка органіка на цій планеті", EXOBIOLOGY_SAMPLES.getAction());
+        map.put("відстань до останнього біозразка, як далеко до зразка, відстань до останньої органіки, дистанція до біозразка, навігація до біозразка", DISTANCE_TO_LAST_BIO_SAMPLE.getAction());
+        map.put("аналіз біому, який біом {key:X}, планетарний біом, аналіз атмосфери, яке життя тут, тип біому", PLANET_BIOME_ANALYSIS.getAction());
+        map.put("зоряні об'єкти, планети в системі, посадкові планети, планета чи місяць придатні для посадки, тіла в системі, які планети, скільки планет, кільця, крижані кільця", QUERY_STELLAR_OBJETS.getAction());
+        map.put("сигнали в системі, які сигнали в системі, що є в системі, виявлені сигнали, fss сигнали, hotspots, resource extraction sites, конфліктні зони, емісії", QUERY_STELLAR_SIGNALS.getAction());
+        map.put("геосигнали, геологічні сигнали, вулканічні сигнали, геологічна активність, вулканічна активність", QUERY_GEO_SIGNALS.getAction());
+
+        map.put("авіаносці в системі, carriers у системі, скільки авіаносців, чи є авіаносці поруч", QUERY_CARRIERS.getAction());
+        map.put("маршрут авіаносця, навігація авіаносця, шлях авіаносця, скільки стрибків на маршруті авіаносця, стрибків залишилось", CARRIER_ROUTE_ANALYSIS.getAction());
+        map.put("маршрут авіаносця, куди летить авіаносець, наступний стрибок авіаносця, кінцева точка авіаносця", CARRIER_ROUTE.getAction());
+        map.put("тритій авіаносця, паливо авіаносця, скільки тритію, рівень тритію, резерв тритію", CARRIER_TRITIUM_SUPPLY.getAction());
+        map.put("статус авіаносця, фінанси авіаносця, баланс авіаносця, огляд авіаносця, кошти авіаносця, скільки авіаносець може працювати, запас ходу авіаносця", CARRIER_STATUS.getAction());
+        map.put("eta авіаносця, коли прибуде авіаносець, скільки до прибуття авіаносця, час стрибка авіаносця", CARRIER_ETA.getAction());
+        map.put("відстань до авіаносця, де наш авіаносець, як далеко авіаносець, дистанція до авіаносця", DISTANCE_TO_CARRIER.getAction());
+        map.put("безпека системи, контроль фракції, хто контролює систему, рівень безпеки, власник системи, домінуюча фракція", SYSTEM_SECURITY_ANALYSIS.getAction());
+        map.put("торговий профіль, торгові налаштування, параметри торгівлі, торгова конфігурація, критерії торгівлі", TRADE_PROFILE_ANALYSIS.getAction());
+        map.put("відстань до зоряного об'єкта, як далеко до тіла, відстань до планети {key:X}, відстань до місяця, як далеко до станції, дистанція до тіла", DISTANCE_TO_BODY.getAction());
+        map.put("останній скан, що ми сканували, останній просканований об'єкт, найсвіжіший скан", LAST_SCAN_ANALYSIS.getAction());
+        map.put("інвентар матеріалів {key:X}, скільки предметів {key:X}, скільки матеріалів {key:X}, чи є матеріал {key:X}, скільки {key:X} у нас є, інженерний матеріал {key:X}, сировинний матеріал {key:X}, manufactured матеріал {key:X}, закодований матеріал {key:X}", MATERIALS_INVENTORY.getAction());
+        map.put("матеріали планети, матеріали тут, які матеріали на цій планеті, поверхневі матеріали, поклади матеріалів, мінерали на планеті", PLANET_MATERIALS.getAction());
+        map.put("прибуток дослідження, вартість відкриттів, скільки коштує дослідження, цінність сканів, прибуток картографування, цінність екзобіології", EXPLORATION_PROFITS.getAction());
+        map.put("де я знаходжуся, де ми знаходимося, наша позиція, в якій системі ми, де я, наші координати, поточна система, на якій планеті ми, поточна позиція, довжина дня", CURRENT_LOCATION.getAction());
+        map.put("інформація про ціль fsd, аналіз пункту призначення, яку зірку ми вибрали, аналіз fsd цілі", FSD_TARGET_ANALYSIS.getAction());
+        map.put("прокладений маршрут, паливо на наступній зупинці, наявність палива на маршруті, аналіз маршруту, ми вже на місці, поточний маршрут, скільки стрибків залишилось, наступна зірка scoopable", PLOTTED_ROUTE_ANALYSIS.getAction());
+        map.put("торговий маршрут, поточний торговий план, чим ми торгуємо, наш торговий план, торгові етапи", TRADE_ROUTE_ANALYSIS.getAction());
+        map.put("оснащення, покращення корабля, доступні модулі, які модулі на станції, доступне обладнання, купити модулі, частини корабля", LOCAL_OUTFITTING.getAction());
+        map.put("верф, кораблі на продаж, які кораблі на станції, купити корабель, доступні кораблі, новий корабель", LOCAL_SHIPYARD.getAction());
+        map.put("що у вантажному відсіку, що ми веземо, вміст вантажу, товари на борту, чим ми завантажені", CARGO_HOLD_CONTENTS.getAction());
+        map.put("профіль гравця", PLAYER_PROFILE_ANALYSIS.getAction());
+        map.put("компонування корабля, звіт про пошкодження, модулі корабля, готовність до бою, обладнання корабля, характеристики корабля, на чому я лечу, що встановлено, генератор щитів, посилення корпусу, сенсори, двигуни, frameshift, паливний ківш", SHIP_LOADOUT.getAction());
+        map.put("деталі станції, які сервіси тут, які послуги тут, сервіси на станції, що пропонує станція, інформація про станцію, обладнання станції, що є на цій станції, доступні сервіси", STATION_DETAILS.getAction());
+        map.put("нагороди за голови, загальний bounty, скільки bounty, заробіток з bounty, кредити за bounty", TOTAL_BOUNTIES.getAction());
+        map.put("відстань до бульбашки, відстань до sol, відстань від sol, відстань до землі, як далеко від бульбашки, як далеко від цивілізації, відстань від населеного космосу", DISTANCE_TO_BUBBLE.getAction());
+        map.put("поточний час, скільки часу, час на землі, галактичний час, utc час, реальний час", TIME_IN_ZONE.getAction());
+        map.put("нагадування, яке було нагадування, нагадування пункту призначення, чи є нагадування, що ми встановили як нагадування", REMINDER.getAction());
+        map.put("локальні ринки, ринки на станціях і поселеннях, ринки на аванпостах у системі", ANALYZE_MARKETS.getAction());
+    }
+}


### PR DESCRIPTION
This PR adds an initial proof of concept for multilingual command/query routing.

Main changes:
- moved the existing English action aliases into a dedicated EnglishAiActionAliases provider
- added separate draft alias providers for Russian, Ukrainian, and German
- added a hardcoded active language selector for now
- simplified AiActionsMap so it delegates alias registration to the selected provider
- adjusted Reducer to use Unicode-aware tokenization
- preserved exact alias matches as candidates, without replacing LLM-based semantic classification
- extended prompt rules so command/query classification is not English-only

The goal is not to replace the LLM-based intent recognition with fixed phrases. The aliases are used as language-specific candidate hints, while the LLM still performs the final semantic action selection.

Tested locally with Mistral and the multilingual Sherpa-ONNX Parakeet STT model:

csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8

Examples that route correctly on my local setup:
- включи свет → toggle_lights_on_off
- выпусти шасси → deploy_landing_gear
- где мы находимся → query_current_location
- на какой станции я нахожусь → query_station_details
- какие сервисы есть на станции → query_station_details

The Russian, Ukrainian, and German aliases should be considered draft translations. All three languages still need final proofreading and refinement by fluent/native speakers before being treated as production-ready.

Notes:
- the active language selector is currently hardcoded and should eventually be replaced by a proper UI/config setting
- the STT model itself is not included in this PR
- this PR focuses on command/query routing, not localized AI responses yet