### PR TITLE
Fix blank ship names in fleet display

### DIFF
--- a/app/src/main/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverter.java
+++ b/app/src/main/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverter.java
@@ -4,6 +4,7 @@ import elite.intel.gameapi.journal.events.LoadoutEvent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static elite.intel.util.StringUtls.toReadableModuleName;
 
@@ -25,9 +26,39 @@ public class LoadoutConverter {
         dto.setShipId(event.getShipId());
         dto.setShipIdent(event.getShipIdent());
         dto.setShipMake(event.getShip());
-        dto.setShipName(event.getShipName());
+        dto.setShipName(toDisplayShipName(event));
         dto.setUnladenMass(event.getUnladenMass());
         return dto;
+    }
+
+    /**
+     * Returns the player-defined ship name when present, otherwise falls back to
+     * the journal ship type with a capitalized first letter. Returns null when
+     * neither value is usable so existing Unknown fallback text can still apply.
+     */
+    public static String toDisplayShipName(LoadoutEvent event) {
+        return toDisplayShipName(event.getShipName(), event.getShip());
+    }
+
+    static String toDisplayShipName(String shipName, String ship) {
+        String normalizedShipName = normalizeBlank(shipName);
+        if (normalizedShipName != null) {
+            return normalizedShipName;
+        }
+
+        String normalizedShip = normalizeBlank(ship);
+        if (normalizedShip == null) {
+            return null;
+        }
+        return normalizedShip.substring(0, 1).toUpperCase(Locale.ROOT) + normalizedShip.substring(1);
+    }
+
+    private static String normalizeBlank(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static List<ModuleDto> toModules(List<LoadoutEvent.Module> modules) {

--- a/app/src/main/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverter.java
+++ b/app/src/main/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverter.java
@@ -40,7 +40,10 @@ public class LoadoutConverter {
         return toDisplayShipName(event.getShipName(), event.getShip());
     }
 
-    static String toDisplayShipName(String shipName, String ship) {
+    /**
+     * Normalizes a stored or journal ship name into the display name used by the UI.
+     */
+    public static String toDisplayShipName(String shipName, String ship) {
         String normalizedShipName = normalizeBlank(shipName);
         if (normalizedShipName != null) {
             return normalizedShipName;

--- a/app/src/main/java/elite/intel/gameapi/journal/subscribers/LoadoutSubscriber.java
+++ b/app/src/main/java/elite/intel/gameapi/journal/subscribers/LoadoutSubscriber.java
@@ -37,7 +37,7 @@ public class LoadoutSubscriber {
             );
 
 
-            String shipName = event.getShipName() != null ? event.getShipName() : event.getShip();
+            String shipName = LoadoutConverter.toDisplayShipName(event);
             playerSession.setCurrentShipName(shipName);
             playerSession.setCurrentShip(event.getShip());
             playerSession.setShipLoadout(LoadoutConverter.toShipLoadOutDto(event));

--- a/app/src/main/java/elite/intel/ui/view/PlayerTabPanel.java
+++ b/app/src/main/java/elite/intel/ui/view/PlayerTabPanel.java
@@ -10,6 +10,7 @@ import elite.intel.db.dao.ShipSettingsDao;
 import elite.intel.db.managers.ShipManager;
 import elite.intel.db.managers.ShipSettingsManager;
 import elite.intel.gameapi.EventBusManager;
+import elite.intel.gameapi.journal.events.dto.shiploadout.LoadoutConverter;
 import elite.intel.session.PlayerSession;
 import elite.intel.session.SystemSession;
 import elite.intel.ui.event.AppLogEvent;
@@ -161,8 +162,8 @@ public class PlayerTabPanel extends JPanel {
 
         List<ShipDao.Ship> ships = ShipManager.getInstance().getAllShips();
         ships.sort((a, b) -> {
-            String nameA = a.getShipName() == null ? "" : a.getShipName();
-            String nameB = b.getShipName() == null ? "" : b.getShipName();
+            String nameA = displayShipName(a);
+            String nameB = displayShipName(b);
             return nameA.compareToIgnoreCase(nameB);
         });
         fleetScrollPane.setViewportView(buildFleetGrid(ships));
@@ -222,7 +223,8 @@ public class PlayerTabPanel extends JPanel {
             c.gridy = gridRow;
             c.gridx = 0;
             c.weightx = 0.30;
-            JLabel nameLabel = new JLabel(ship.getShipName() != null ? ship.getShipName() : "Unknown");
+            String shipDisplayName = displayShipName(ship);
+            JLabel nameLabel = new JLabel(shipDisplayName);
             nameLabel.setForeground(FG);
             panel.add(nameLabel, c);
 
@@ -232,7 +234,7 @@ public class PlayerTabPanel extends JPanel {
             voiceCombo.addActionListener(e -> {
                 String voiceName = (String) voiceCombo.getSelectedItem();
                 ship.setVoice(voiceName);
-                String tts = "Hello " + playerSession.getPlayerName() + ", I am " + ship.getShipName() + ", at your service " + Ranks.getPlayerHonorific();
+                String tts = "Hello " + playerSession.getPlayerName() + ", I am " + shipDisplayName + ", at your service " + Ranks.getPlayerHonorific();
                 EventBusManager.publish(new AiVoxDemoEvent(tts, voiceName));
                 ShipManager.getInstance().saveShip(ship);
             });
@@ -261,7 +263,7 @@ public class PlayerTabPanel extends JPanel {
             c.fill = GridBagConstraints.NONE;
             JButton shipSettingsBtn = makeButtonSubtle("");
             shipSettingsBtn.setIcon(scaledIcon("/images/handicapped.png"));
-            shipSettingsBtn.addActionListener(e -> ShipSettingsPopup.create(panel, ship.getShipName(), shipSettings).setVisible(true));
+            shipSettingsBtn.addActionListener(e -> ShipSettingsPopup.create(panel, shipDisplayName, shipSettings).setVisible(true));
             panel.add(shipSettingsBtn, c);
             c.fill = GridBagConstraints.HORIZONTAL;
         }
@@ -275,6 +277,11 @@ public class PlayerTabPanel extends JPanel {
         panel.add(Box.createGlue(), c);
 
         return panel;
+    }
+
+    private String displayShipName(ShipDao.Ship ship) {
+        String displayName = LoadoutConverter.toDisplayShipName(ship.getShipName(), ship.getShipIdentifier());
+        return displayName == null ? "Unknown" : displayName;
     }
 
     private JLabel makeColHeader(String text) {

--- a/app/src/test/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverterTest.java
+++ b/app/src/test/java/elite/intel/gameapi/journal/events/dto/shiploadout/LoadoutConverterTest.java
@@ -1,0 +1,37 @@
+package elite.intel.gameapi.journal.events.dto.shiploadout;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LoadoutConverterTest {
+
+    @Test
+    void usesTrimmedShipNameWhenPresent() {
+        assertEquals("My Ship", LoadoutConverter.toDisplayShipName("  My Ship  ", "mandalay"));
+    }
+
+    @Test
+    void fallsBackToCapitalizedShipWhenShipNameIsBlank() {
+        assertEquals("Mandalay", LoadoutConverter.toDisplayShipName("", "mandalay"));
+        assertEquals("Mandalay", LoadoutConverter.toDisplayShipName("   ", "mandalay"));
+    }
+
+    @Test
+    void fallsBackToCapitalizedTrimmedShipWhenShipNameIsMissing() {
+        assertEquals("Mandalay", LoadoutConverter.toDisplayShipName(null, "  mandalay  "));
+    }
+
+    @Test
+    void returnsNullForUnknownShipFallbackWhenShipNameAndShipAreBlank() {
+        assertNull(
+                LoadoutConverter.toDisplayShipName(null, null),
+                "Unknown ship fallback should remain available when both names are missing"
+        );
+        assertNull(
+                LoadoutConverter.toDisplayShipName("", "   "),
+                "Unknown ship fallback should remain available when both names are blank"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #43

Fixes blank ship names from Elite Dangerous `Loadout` events.

`ShipName` is now used only when it is not blank. If it is missing or blank, the code falls back to the `Ship` value and formats it for display, e.g. `mandalay` -> `Mandalay`.

Also adds focused tests for the Loadout ship name normalization.
