### PR TITLE
fix: support new Google Gemini API keys starting with AQ.

### DIFF
--- a/app/src/main/java/elite/intel/ai/KeyDetector.java
+++ b/app/src/main/java/elite/intel/ai/KeyDetector.java
@@ -43,7 +43,7 @@ public class KeyDetector {
             Map.entry(ProviderEnum.OPENAI, Pattern.compile("^sk-[a-zA-Z0-9_-]{161}$")),
             Map.entry(ProviderEnum.GOOGLE_STT, Pattern.compile("^AIzaSy[a-zA-Z0-9_-]{33}$")),
             Map.entry(ProviderEnum.GOOGLE_TTS, Pattern.compile("^AIzaSy[a-zA-Z0-9_-]{33}$")),
-            Map.entry(ProviderEnum.GEMINI, Pattern.compile("^AIzaSy[a-zA-Z0-9_-]{33}$")),
+            Map.entry(ProviderEnum.GEMINI, Pattern.compile("^(AIzaSy[a-zA-Z0-9_-]{33}|AQ\\.[a-zA-Z0-9_.-]{30,150})$")),
             Map.entry(ProviderEnum.ANTHROPIC, Pattern.compile("^sk-ant-api\\d{2}-[a-zA-Z0-9_-]{93,97}$")),
             Map.entry(ProviderEnum.AWS_LLM, Pattern.compile("^(AKIA|ASIA)[A-Z0-9]{16}$")),
             Map.entry(ProviderEnum.AWS_STT, Pattern.compile("^(AKIA|ASIA)[A-Z0-9]{16}$")),


### PR DESCRIPTION
Google has updated the format of API keys in Google AI Studio. They now start with "AQ." instead of "AIzaSy", causing KeyDetector to misidentify them and fall back to Ollama.